### PR TITLE
feat: inverse mode

### DIFF
--- a/cmd/dev/ci/monorepo/run_test.go
+++ b/cmd/dev/ci/monorepo/run_test.go
@@ -1,0 +1,55 @@
+package monorepo
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDryRun(t *testing.T) {
+	fmt.Println("TestDryRun")
+	c := Component{ID: "component1", Name: "", Path: "./"}
+	cmdLine := "UnknownCommand"
+	err := runCmd(&c, cmdLine, true)
+	assert.NoError(t, err, "Expected no error, as dryRun only prints out the command, but does not execute it!")
+
+	err = runCmd(&c, cmdLine, false)
+	assert.Error(t, err, "Expected error as comannd specified does not exist!")
+}
+
+func TestInverseRun(t *testing.T) {
+	fmt.Println("TestDryRun")
+	c := Component{ID: "component1", Name: "", Path: "./"}
+
+	//not the nicest way to test, but for now the fastest. We use the error if a command gets executed to test if
+	//the conditions are handled correctly. In addition we can define a test struct with inputs and outputs to reduce
+	//code.
+	cmdLine := "unknowncmd"
+	err := runWrapper(&c, cmdLine, ModeCurrentAffected, true, false, false, false)
+	assert.Error(t, err, "Expected error, as component is affected and inverseMode set to false!")
+	err = runWrapper(&c, cmdLine, ModeCurrentAffected, false, false, false, true)
+	assert.Error(t, err, "Expected error, as component is not affected and inverseMode set to true!")
+	err = runWrapper(&c, cmdLine, ModeCurrentAffected, true, false, false, true)
+	assert.NoError(t, err, "Expected no error, as component is affected and inverseMode set to true!")
+	err = runWrapper(&c, cmdLine, ModeCurrentAffected, false, false, false, false)
+	assert.NoError(t, err, "Expected no error, as component is not affected and inverseMode set to false!")
+
+	err = runWrapper(&c, cmdLine, ModeCurrentChanged, false, true, false, false)
+	assert.Error(t, err, "Expected error, as component has changed and inverseMode set to false!")
+	err = runWrapper(&c, cmdLine, ModeCurrentChanged, false, false, false, true)
+	assert.Error(t, err, "Expected error, as component has not changed and inverseMode set to true!")
+	err = runWrapper(&c, cmdLine, ModeCurrentChanged, false, true, false, true)
+	assert.NoError(t, err, "Expected no error, as component has changed and inverseMode set to true!")
+	err = runWrapper(&c, cmdLine, ModeCurrentChanged, false, false, false, false)
+	assert.NoError(t, err, "Expected no error, as component has not changed and inverseMode set to false!")
+
+	err = runWrapper(&c, cmdLine, ModeCurrentChanged, false, true, true, false)
+	assert.Error(t, err, "Expected error, as component is involved and inverseMode set to false!")
+	err = runWrapper(&c, cmdLine, ModeCurrentChanged, false, false, false, true)
+	assert.Error(t, err, "Expected error, as component is not involved and inverseMode set to true!")
+	err = runWrapper(&c, cmdLine, ModeCurrentChanged, false, true, true, true)
+	assert.NoError(t, err, "Expected no error, as component is involved and inverseMode set to true!")
+	err = runWrapper(&c, cmdLine, ModeCurrentChanged, false, false, false, false)
+	assert.NoError(t, err, "Expected no error, as component is not involved and inverseMode set to false!")
+}


### PR DESCRIPTION
Normally the command specified for 
```
ory dev ci monorepo run -c "echo hello" -m current_changed
```
are only executed if (in the example above the component in the current directory is changed. For our CircleCI case it would be beneficial to halt the current job, if the current component is not changed, affected or involved. 

## Proposed changes
Introduce a flag `--inverse` which will execute the commands if the component is not changed/affected/involved.
```
ory dev ci monorepo run -c "circleci-agent step halt" -m current_involved --inverse
```
In this example we would halt the CircleCI  job if the current component is not involved.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).