### PR TITLE
fix: add schema path parameter to dev render version schema

### DIFF
--- a/cmd/dev/schema/render_version.go
+++ b/cmd/dev/schema/render_version.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"strings"
 
 	"github.com/ory/x/jsonschemax"
@@ -22,9 +23,9 @@ import (
 var _ = pkger.Include("../../../.schema")
 
 var RenderVersion = &cobra.Command{
-	Use:   "render-version <project-name> <new-version>",
-	Args:  cobra.ExactArgs(2),
-	Short: "Renders the version schema for <project-name> and <new-version> in the current directory.",
+	Use:   "render-version <project-name> <new-version> <schema-path>",
+	Args:  cobra.ExactArgs(3),
+	Short: "Renders the version schema for <project-name> and <new-version> in the current directory. The `$ref` is pointing to the <schema-path> relative to the repo root.",
 	Run:   addVersionToSchema,
 }
 
@@ -38,7 +39,7 @@ func addVersionToSchema(_ *cobra.Command, args []string) {
 		return
 	}
 
-	ref := fmt.Sprintf("https://raw.githubusercontent.com/ory/%s/%s/.schema/config.schema.json", project, newVersion)
+	ref := "https://raw.githubusercontent.com/ory" + path.Join(project, newVersion, args[2])
 	newVersionEntry := fmt.Sprintf(`
 {
 	"allOf": [

--- a/cmd/dev/schema/render_version.go
+++ b/cmd/dev/schema/render_version.go
@@ -39,7 +39,7 @@ func addVersionToSchema(_ *cobra.Command, args []string) {
 		return
 	}
 
-	ref := "https://raw.githubusercontent.com/ory" + path.Join(project, newVersion, args[2])
+	ref := "https://raw.githubusercontent.com/ory/" + path.Join(project, newVersion, args[2])
 	newVersionEntry := fmt.Sprintf(`
 {
 	"allOf": [

--- a/cmd/dev/schema/render_version_test.go
+++ b/cmd/dev/schema/render_version_test.go
@@ -53,7 +53,7 @@ func TestAddVersionToSchema(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, os.Chdir(testDir))
 
-	addVersionToSchema(nil, []string{"hydra", "v1.0.0"})
+	addVersionToSchema(nil, []string{"hydra", "v1.0.0", ".schema/config.schema.json"})
 
 	require.NoError(t, os.Chdir(wd))
 


### PR DESCRIPTION
## Related issue

With go1.16 embed the config schemas are not in one conform place anymore.