### PR TITLE
fix: update url of 'we are hiring' section

### DIFF
--- a/cmd/dev/newsletter/stub/changelog.html.expected
+++ b/cmd/dev/newsletter/stub/changelog.html.expected
@@ -1228,7 +1228,7 @@ Settled on 3 iterations.
     <br /><br />
     
     <article style="border-top: 1px solid #5528FF;">
-      <p style="font-size: 16px; font-weight: 400; line-height: 2; margin-top: 16px; text-align: center">Interested in working at ORY full time?<br>&nbsp;<a href="https://github.com/ory/jobs" target="_blank">We are hiring!</a></p>
+      <p style="font-size: 16px; font-weight: 400; line-height: 2; margin-top: 16px; text-align: center">Interested in working at ORY full time?<br>&nbsp;<a href="https://www.ory.sh/jobs/" target="_blank">We are hiring!</a></p>
     </article>
   </main>
   

--- a/view/mail-body.html
+++ b/view/mail-body.html
@@ -108,7 +108,7 @@
     <br /><br />
     <!-- careers / top border uses color -->
     <article style="border-top: 1px solid {{.BrandColor}};">
-      <p style="font-size: 16px; font-weight: 400; line-height: 2; margin-top: 16px; text-align: center">Interested in working at ORY full time?<br>&nbsp;<a href="https://github.com/ory/jobs" target="_blank">We are hiring!</a></p>
+      <p style="font-size: 16px; font-weight: 400; line-height: 2; margin-top: 16px; text-align: center">Interested in working at ORY full time?<br>&nbsp;<a href="https://www.ory.sh/jobs/" target="_blank">We are hiring!</a></p>
     </article>
   </main>
   <!-- footer / top border uses color -->


### PR DESCRIPTION
observation: the newsletter pointed to [ory/jobs](https://github.com/ory/jobs) 
fix: the newsletter now points to our dedicated [jobs page](https://www.ory.sh/jobs/)