### PR TITLE
feat: add better redirect and logout functionality

### DIFF
--- a/cmd/cloud/proxy/proxy_local.go
+++ b/cmd/cloud/proxy/proxy_local.go
@@ -3,6 +3,8 @@ package proxy
 import (
 	"fmt"
 
+	"github.com/ory/x/urlx"
+
 	"github.com/spf13/cobra"
 
 	"github.com/ory/cli/cmd/cloud/remote"
@@ -40,6 +42,7 @@ func NewProxyLocalCmd() *cobra.Command {
 				isLocal:         true,
 				upstream:        args[0],
 				hostPort:        fmt.Sprintf("localhost:%d", port),
+				selfURL:         urlx.ParseOrPanic(fmt.Sprintf("https://localhost:%d", port)),
 			}
 
 			return run(cmd, conf)

--- a/cmd/cloud/proxy/proxy_production.go
+++ b/cmd/cloud/proxy/proxy_production.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/spf13/cobra"
 
@@ -25,7 +26,7 @@ If you want to expose the application / proxy at a specific port, append the por
 
 	$ ory proxy remote --port 4000 \
 		http://127.0.0.1:3000 \
-		example.org:8080
+		https://example.org:8080
 
 %s
 `, jwtHelp),
@@ -38,6 +39,11 @@ If you want to expose the application / proxy at a specific port, append the por
 		   To test your Regular Expression, head over to https://regex101.com and select "Golang" on the left.
 		*/
 		RunE: func(cmd *cobra.Command, args []string) error {
+			selfUrl, err := url.ParseRequestURI(args[1])
+			if err != nil {
+				return err
+			}
+
 			conf := &config{
 				port:            flagx.MustGetInt(cmd, PortFlag),
 				noCert:          true,
@@ -46,7 +52,8 @@ If you want to expose the application / proxy at a specific port, append the por
 				consoleEndpoint: flagx.MustGetString(cmd, remote.FlagConsoleAPI),
 				isLocal:         false,
 				upstream:        args[0],
-				hostPort:        args[1],
+				hostPort:        selfUrl.Host,
+				selfURL:         selfUrl,
 			}
 
 			return run(cmd, conf)


### PR DESCRIPTION
BREAKING CHANGES: This patch adds logout capabilities and improved redirection handling. To achieve that we have changed a few things:

- The JSON Web Keys to validate Ory Proxy's JSON Web Tokens has moved from `/.ory/jwks.json` to `/.ory/proxy/jwks.json`.
- `ory proxy production` previously required a host to be specified (e.g. `example.org:1234`). From now on, you must specify a URL (e.g. `https://example.org:1234`).

Additionally, the `--protect-path-prefix` flag has been removed. We originally introduced this flag to get started easily. Defining policies on what should be protected and what not can however become quite complex. From regular expressions, to glob matching, to exclusions. This clashed with our vision of a simple to use CLI. Therefore, this feature has been removed.

Please use a middleware which redirects to one of the endpoints (e.g. `/.ory/init/login`) if no authentication can be found.