### PR TITLE
chore: update repository template to e424c0a0

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,13 +13,21 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: |
-            Thank you for opening this issue. It appears that the request for more information (e.g. providing the software version, providing logs, ...) has not yet been completed. Therefore this issue will be automatically
-            closed in 7 days, assuming that the issue has been resolved.
-          stale-pr-message: |
-            Thank you for opening this pull request. It appears that a request for e.g. information has not yet been completed. Therefore this issue will be automatically
-            closed in 7 days, assuming that the proposed change is no longer required or has otherwise been resolved.
+            I am marking this issue as stale as it has not received any engagement from the community or maintainers in over half a year. That does not imply that the issue has no merit! If you feel strongly about this issue
+
+            - open a PR referencing and resolving the issue;
+            - leave a comment on it and discuss ideas how you could contribute towards resolving it;
+            - open a new issue with updated details and a plan on resolving the issue.
+
+            We are cleaning up issues every now and then, primarily to keep the 4000+ issues in our backlog in check and to [prevent](https://www.jeffgeerling.com/blog/2020/saying-no-burnout-open-source-maintainer) [maintainer](https://www.jeffgeerling.com/blog/2016/why-i-close-prs-oss-project-maintainer-notes) [burnout](https://docs.brew.sh/Maintainers-Avoiding-Burnout). Burnout in open source maintainership is a [widespread](https://opensource.guide/best-practices/#its-okay-to-hit-pause) and serious issue. It can lead to severe personal and health issues as well as [enabling catastrophic](https://haacked.com/archive/2019/05/28/maintainer-burnout/) [attack vectors](https://www.gradiant.org/en/blog/open-source-maintainer-burnout-as-an-attack-surface/).
+
+            Thank you for your understanding and to anyone who participated in the issue! 🙏✌️
+
+            If you feel strongly about this issues and have ideas on resolving it, please comment. Otherwise it will be closed in 30 days!
           stale-issue-label: 'stale'
-          stale-pr-label: 'stale'
-          only-labels: 'needs more info'
-          days-before-stale: 7
-          days-before-close: 7
+          exempt-issue-labels: 'bug,blocking,docs'
+          days-before-stale: 180
+          days-before-close: 30
+          exempt-milestones: true
+          exempt-assignees: true
+          only-pr-labels: 'stale'

--- a/npm/index.js
+++ b/npm/index.js
@@ -1,20 +1,18 @@
-var binwrap = require("binwrap");
-var path = require("path");
+var binwrap = require('binwrap')
+var path = require('path')
 
-var packageInfo = require(path.join(__dirname, '..', "package.json"));
-var version = packageInfo.version;
-var root = "https://github.com/ory/cli/releases/download/v" + version;
+var packageInfo = require(path.join(__dirname, '..', 'package.json'))
+var version = packageInfo.version
+var root = 'https://github.com/ory/cli/releases/download/v' + version
 
 module.exports = binwrap({
   dirname: __dirname,
-  binaries: [
-    "ory"
-  ],
+  binaries: ['ory'],
   urls: {
-    "linux-x64": root + "/ory_"+version+"_linux_64-bit.tar.gz",
-    "win32-x64": root + "/ory_"+version+"_windows_64-bit.zip",
-    "darwin-x64": root + "/ory_"+version+"_macOS_64-bit.tar.gz",
+    'linux-x64': root + '/ory_' + version + '_linux_64-bit.tar.gz',
+    'win32-x64': root + '/ory_' + version + '_windows_64-bit.zip',
+    'darwin-x64': root + '/ory_' + version + '_macOS_64-bit.tar.gz',
     // We do not have an M1 build yet:
-    "darwin-arm64": root + "/ory_"+version+"_macOS_64-bit.tar.gz",
+    'darwin-arm64': root + '/ory_' + version + '_macOS_64-bit.tar.gz'
   }
-});
+})


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/e424c0a0a2dd85c585c0be32e8ada257c3fe8021.