### PR TITLE
fix: use https to clone instead

### DIFF
--- a/cmd/dev/release/notify/draft.go
+++ b/cmd/dev/release/notify/draft.go
@@ -34,7 +34,7 @@ var draft = &cobra.Command{
 				[]byte(`{"private": true, "version": "0.0.0"}`), 0600))
 		}
 
-		presetDir := pkg.GitClone("git@github.com:ory/changelog.git")
+		presetDir := pkg.GitClone("https://github.com/ory/changelog.git")
 		pkg.Check(pkg.NewCommandIn(presetDir, "npm", "i").Run())
 
 		commitMessage := pkg.CommandGetOutput("git", "log", "--format=%B", "-n", "1", gitHash)

--- a/cmd/dev/release/publish.go
+++ b/cmd/dev/release/publish.go
@@ -152,10 +152,10 @@ Are you sure you want to proceed without creating a pre version first?`, current
 
 		switch cfg.Project {
 		case "hydra":
-			pkg.GitTagRelease(pkg.GitClone("git@github.com:ory/hydra-login-consent-node.git"), false, dry, nextVersion, nil)
+			pkg.GitTagRelease(pkg.GitClone("https://github.com/ory/hydra-login-consent-node.git"), false, dry, nextVersion, nil)
 		case "kratos":
-			pkg.GitTagRelease(pkg.GitClone("git@github.com:ory/kratos-selfservice-ui-node.git"), false, dry, nextVersion, nil)
-			pkg.GitTagRelease(pkg.GitClone("git@github.com:ory/kratos-selfservice-ui-react-native.git"), false, dry, nextVersion, nil)
+			pkg.GitTagRelease(pkg.GitClone("https://github.com/ory/kratos-selfservice-ui-node.git"), false, dry, nextVersion, nil)
+			pkg.GitTagRelease(pkg.GitClone("https://github.com/ory/kratos-selfservice-ui-react-native.git"), false, dry, nextVersion, nil)
 		}
 
 		fmt.Printf("Successfully released version: v%s\n", nextVersion.String())


### PR DESCRIPTION
Using ssh to clone [breaks in CI](https://github.com/ory/release-canary/runs/4789189676?check_suite_focus=true#step:2:133) due to the lack of an ssh key. Simply using https instead should resolve this.