### PR TITLE
fix: use ORY_BOT_SSH_KEY

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -153,4 +153,4 @@ jobs:
           mailchmip_segment_id: 11398953
           mailchimp_api_key: ${{ secrets.MAILCHIMP_API_KEY }}
           draft: 'false'
-          ssh_key: ${{ secrets.SSH_KEY }}
+          ssh_key: ${{ secrets.ORY_BOT_SSH_KEY }}


### PR DESCRIPTION
The production `newsletter-send` workflow was using the wrong env var for the ssh key.