### PR TITLE
fix: render schema should require version and support latest

### DIFF
--- a/cmd/dev/release/publish.go
+++ b/cmd/dev/release/publish.go
@@ -3,10 +3,11 @@ package release
 import (
 	"bytes"
 	"fmt"
-	"github.com/Masterminds/semver/v3"
 	"os"
 	"regexp"
 	"strings"
+
+	"github.com/Masterminds/semver/v3"
 
 	"github.com/spf13/cobra"
 

--- a/cmd/dev/schema/expected/render_version_test/.schema/version.schema.json
+++ b/cmd/dev/schema/expected/render_version_test/.schema/version.schema.json
@@ -1,9 +1,24 @@
 {
     "$id": "https://github.com/ory/cli/cmd/dev/schema/fixtures/render_version_test/.schema/version.schema.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "Test Fixture schema.",
-    "type": "object",
     "oneOf": [
+        {
+            "allOf": [
+                {
+                    "properties": {
+                        "version": {
+                            "const": "v1.0.0"
+                        }
+                    },
+                    "required": [
+                        "version"
+                    ]
+                },
+                {
+                    "$ref": "https://raw.githubusercontent.com/ory/hydra/v1.0.0/.schema/config.schema.json"
+                }
+            ]
+        },
         {
             "allOf": [
                 {
@@ -11,7 +26,10 @@
                         "version": {
                             "const": "v0.0.0"
                         }
-                    }
+                    },
+                    "required": [
+                        "version"
+                    ]
                 },
                 {
                     "$ref": "https://raw.githubusercontent.com/ory/hydra/v0.0.0/.schema/config.schema.json"
@@ -21,16 +39,36 @@
         {
             "allOf": [
                 {
-                    "properties": {
-                        "version": {
-                            "const": "v1.0.0"
+                    "oneOf": [
+                        {
+                            "properties": {
+                                "version": {
+                                    "type": "string",
+                                    "maxLength": 0
+                                }
+                            },
+                            "required": [
+                                "version"
+                            ]
+                        },
+                        {
+                            "not": {
+                                "properties": {
+                                    "version": {}
+                                },
+                                "required": [
+                                    "version"
+                                ]
+                            }
                         }
-                    }
+                    ]
                 },
                 {
-                    "$ref": "https://raw.githubusercontent.com/ory/hydra/v1.0.0/.schema/config.schema.json"
+                    "$ref": "#/oneOf/0/allOf/1"
                 }
             ]
         }
-    ]
+    ],
+    "title": "Test Fixture schema.",
+    "type": "object"
 }

--- a/cmd/dev/schema/fixtures/render_version_test/.schema/version.schema.json
+++ b/cmd/dev/schema/fixtures/render_version_test/.schema/version.schema.json
@@ -11,10 +11,45 @@
             "version": {
               "const": "v0.0.0"
             }
-          }
+          },
+          "required": [
+            "version"
+          ]
         },
         {
           "$ref": "https://raw.githubusercontent.com/ory/hydra/v0.0.0/.schema/config.schema.json"
+        }
+      ]
+    },
+    {
+      "allOf": [
+        {
+          "oneOf": [
+            {
+              "properties": {
+                "version": {
+                  "type": "string",
+                  "maxLength": 0
+                }
+              },
+              "required": [
+                "version"
+              ]
+            },
+            {
+              "not": {
+                "properties": {
+                  "version": {}
+                },
+                "required": [
+                  "version"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "$ref": "#/oneOf/0/allOf/1"
         }
       ]
     }

--- a/cmd/dev/schema/latest.fragment.schema.json
+++ b/cmd/dev/schema/latest.fragment.schema.json
@@ -1,0 +1,32 @@
+{
+  "allOf": [
+    {
+      "oneOf": [
+        {
+          "properties": {
+            "version": {
+              "type": "string",
+              "maxLength": 0
+            }
+          },
+          "required": [
+            "version"
+          ]
+        },
+        {
+          "not": {
+            "properties": {
+              "version": {}
+            },
+            "required": [
+              "version"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "$ref": "#/oneOf/0/allOf/1"
+    }
+  ]
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,12 +3,14 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
 	"github.com/ory/cli/buildinfo"
 	"github.com/ory/x/cloudx"
 	"github.com/ory/x/cmdx"
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-	"os"
 )
 
 func NewRootCmd() *cobra.Command {

--- a/spec/version_meta.schema.json
+++ b/spec/version_meta.schema.json
@@ -12,60 +12,107 @@
         "oneOf": {
           "type": "array",
           "items": {
-            "type": "object",
-            "required": ["allOf"],
-            "additionalProperties": false,
-            "properties": {
-              "allOf": {
-                "type": "array",
-                "additionalItems": false,
-                "minItems": 2,
-                "items": [
-                  {
-                    "type": "object",
-                    "required": [
-                      "properties"
-                    ],
-                    "additionalProperties": false,
-                    "properties": {
-                      "properties": {
+            "oneOf": [
+              {
+                "type": "object",
+                "required": [
+                  "allOf"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "allOf": {
+                    "type": "array",
+                    "additionalItems": false,
+                    "minItems": 2,
+                    "items": [
+                      {
                         "type": "object",
                         "required": [
-                          "version"
+                          "properties",
+                          "required"
                         ],
                         "additionalProperties": false,
                         "properties": {
-                          "version": {
+                          "properties": {
                             "type": "object",
                             "required": [
-                              "const"
+                              "version"
                             ],
                             "additionalProperties": false,
                             "properties": {
-                              "const": {
-                                "type": "string"
+                              "version": {
+                                "type": "object",
+                                "required": [
+                                  "const"
+                                ],
+                                "additionalProperties": false,
+                                "properties": {
+                                  "const": {
+                                    "type": "string"
+                                  }
+                                }
                               }
+                            }
+                          },
+                          "required": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
                             }
                           }
                         }
+                      },
+                      {
+                        "type": "object",
+                        "required": [
+                          "$ref"
+                        ],
+                        "additionalProperties": false,
+                        "properties": {
+                          "$ref": {
+                            "type": "string"
+                          }
+                        }
                       }
-                    }
-                  },
-                  {
-                    "type": "object",
-                    "required": [
-                      "$ref"
-                    ],
-                    "additionalProperties": false,
-                    "properties": {
-                      "$ref": {
-                        "type": "string"
-                      }
-                    }
+                    ]
                   }
-                ]
+                }
+              },
+              {
+                "const": {
+                  "allOf": [
+                    {
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "version": {
+                              "type": "string",
+                              "maxLength": 0
+                            }
+                          },
+                          "required": [
+                            "version"
+                          ]
+                        },
+                        {
+                          "not": {
+                            "properties": {
+                              "version": {}
+                            },
+                            "required": [
+                              "version"
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "$ref": "#/oneOf/0/allOf/1"
+                    }
+                  ]
+                }
               }
-            }
+            ]
           }
         }
       }


### PR DESCRIPTION
This means that the version schema will from now on match the latest version (i.e. the first one in the `oneOf`). Still the base file has to be manually adjusted.