### PR TITLE
chore: update golangci-lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,6 @@ jobs:
       - run: |
           make test
 
-
   docs:
     name: Generate docs
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: ory/ci/checkout@master
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.17'
+          go-version: '1.18'
       - run: |
           make test
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,9 +17,6 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '^1.17'
-      - uses: golangci/golangci-lint-action@v3
-        with:
-          version: v1.47.2
       - run: |
           make test
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: CI Tasks for Ory CLI
+name: CI
 on:
   push:
     branches:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,11 +17,11 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '^1.17'
-      - run: |
-          make test
       - uses: golangci/golangci-lint-action@v3
         with:
           version: v1.47.2
+      - run: |
+          make test
 
 
   docs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,10 @@ jobs:
           go-version: '^1.17'
       - run: |
           make test
+      - uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.47.2
+
 
   docs:
     name: Generate docs

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,4 +4,4 @@ linters:
 
 linters-settings:
   goimports:
-    local-prefixes: github.com/ory/cli
+    local-prefixes: github.com/ory

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ docs/cli: .bin/clidoc
 
 .PHONY: lint
 lint: .bin/golangci-lint
-		.bin/golangci-lint run ./...
+		.bin/golangci-lint run ./... --timeout=1m
 
 .PHONY: install
 install:

--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,11 @@ docs/cli: .bin/clidoc
 		go build -o .bin/cli -tags sqlite github.com/ory/cli
 
 .bin/golangci-lint: Makefile
-		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.47.2
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b .bin v1.47.2
 
 .PHONY: lint
 lint: .bin/golangci-lint
-		golangci-lint run -v ./...
+		.bin/golangci-lint run -v ./...
 
 .PHONY: install
 install:

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ docs/cli: .bin/clidoc
 
 .PHONY: lint
 lint: .bin/golangci-lint
-		.bin/golangci-lint run -v ./...
+		.bin/golangci-lint run ./...
 
 .PHONY: install
 install:

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ docs/cli: .bin/clidoc
 		go build -o .bin/cli -tags sqlite github.com/ory/cli
 
 .bin/golangci-lint: Makefile
-		bash <(curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh) -d -b .bin v1.28.3
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.47.2
 
 .PHONY: lint
 lint: .bin/golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ docs/cli: .bin/clidoc
 
 .PHONY: lint
 lint: .bin/golangci-lint
-		.bin/golangci-lint run ./... --timeout=1m
+		.bin/golangci-lint run ./... --timeout=10m
 
 .PHONY: install
 install:

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ docs/cli: .bin/clidoc
 
 .PHONY: lint
 lint: .bin/golangci-lint
-		.bin/golangci-lint run ./... --timeout=10m
+		.bin/golangci-lint run -v --timeout=10m ./...
 
 .PHONY: install
 install:

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ install:
 		GO111MODULE=on go install -tags sqlite .
 
 .PHONY: test
-test:
+test: lint
 		go test -p 1 -tags sqlite -count=1 -failfast ./...
 
 # Formats the code

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ docs/cli: .bin/clidoc
 
 .PHONY: lint
 lint: .bin/golangci-lint
-		.bin/golangci-lint run -v --timeout=10m ./...
+		.bin/golangci-lint run --timeout=10m ./...
 
 .PHONY: install
 install:

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ docs/cli: .bin/clidoc
 
 .PHONY: lint
 lint: .bin/golangci-lint
-		.bin/golangci-lint run ./...
+		.bin/golangci-lint run -v ./...
 
 .PHONY: install
 install:

--- a/cmd/clidoc/main.go
+++ b/cmd/clidoc/main.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/ory/cli/cmd"
-
 	"github.com/ory/x/clidoc"
 )
 

--- a/cmd/cloudx/auth.go
+++ b/cmd/cloudx/auth.go
@@ -4,7 +4,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ory/cli/cmd/cloudx/client"
-
 	"github.com/ory/x/cmdx"
 )
 

--- a/cmd/cloudx/auth_test.go
+++ b/cmd/cloudx/auth_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ory/cli/cmd/cloudx"
 	"github.com/ory/cli/cmd/cloudx/client"
 	"github.com/ory/cli/cmd/cloudx/testhelpers"
-
 	cloud "github.com/ory/client-go"
 	"github.com/ory/x/pointerx"
 )

--- a/cmd/cloudx/auth_test.go
+++ b/cmd/cloudx/auth_test.go
@@ -7,15 +7,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pquerna/otp/totp"
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ory/cli/cmd/cloudx"
 	"github.com/ory/cli/cmd/cloudx/client"
 	"github.com/ory/cli/cmd/cloudx/testhelpers"
-
-	"github.com/pquerna/otp/totp"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	cloud "github.com/ory/client-go"
 	"github.com/ory/x/pointerx"

--- a/cmd/cloudx/client/handler.go
+++ b/cmd/cloudx/client/handler.go
@@ -116,7 +116,7 @@ type CommandHelper struct {
 	PwReader         passwordReader
 }
 
-const PasswordReader = "password_reader"
+type PasswordReader struct{}
 
 // NewCommandHelper creates a new CommandHelper instance which handles cobra CLI commands.
 func NewCommandHelper(cmd *cobra.Command) (*CommandHelper, error) {
@@ -138,7 +138,7 @@ func NewCommandHelper(cmd *cobra.Command) (*CommandHelper, error) {
 	pwReader := func() ([]byte, error) {
 		return term.ReadPassword(int(syscall.Stdin))
 	}
-	if p, ok := cmd.Context().Value(PasswordReader).(passwordReader); ok {
+	if p, ok := cmd.Context().Value(PasswordReader{}).(passwordReader); ok {
 		pwReader = p
 	}
 

--- a/cmd/cloudx/client/handler.go
+++ b/cmd/cloudx/client/handler.go
@@ -17,11 +17,8 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/imdario/mergo"
-
-	"github.com/ory/x/jsonx"
-
 	"github.com/gofrs/uuid/v3"
+	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -29,9 +26,9 @@ import (
 	"golang.org/x/term"
 
 	cloud "github.com/ory/client-go"
-
 	"github.com/ory/x/cmdx"
 	"github.com/ory/x/flagx"
+	"github.com/ory/x/jsonx"
 	"github.com/ory/x/stringsx"
 )
 

--- a/cmd/cloudx/client/handler_test.go
+++ b/cmd/cloudx/client/handler_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
-	"fmt"
 	"io"
 	"testing"
 
@@ -57,7 +56,7 @@ func TestCommandHelper(t *testing.T) {
 	}
 
 	t.Run("func=GetProject", func(t *testing.T) {
-		t.Run(fmt.Sprintf("is able to get project"), func(t *testing.T) {
+		t.Run("is able to get project", func(t *testing.T) {
 			p, err := loggedIn.GetProject(project)
 			require.NoError(t, err)
 			assertValidProject(t, p)

--- a/cmd/cloudx/client/sdks.go
+++ b/cmd/cloudx/client/sdks.go
@@ -6,9 +6,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/ory/x/stringsx"
-
 	cloud "github.com/ory/client-go"
+	"github.com/ory/x/stringsx"
 )
 
 func makeCloudConsoleURL(prefix string) string {

--- a/cmd/cloudx/create.go
+++ b/cmd/cloudx/create.go
@@ -1,20 +1,17 @@
 package cloudx
 
 import (
-	"fmt"
+	"github.com/spf13/cobra"
 
 	"github.com/ory/cli/cmd/cloudx/client"
 	"github.com/ory/cli/cmd/cloudx/project"
-
-	"github.com/spf13/cobra"
-
 	"github.com/ory/x/cmdx"
 )
 
 func NewCreateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: fmt.Sprintf("Create Ory Cloud resources"),
+		Short: "Create Ory Cloud resources",
 	}
 	cmd.AddCommand(project.NewCreateProjectCmd())
 	client.RegisterConfigFlag(cmd.PersistentFlags())

--- a/cmd/cloudx/delete.go
+++ b/cmd/cloudx/delete.go
@@ -1,8 +1,6 @@
 package cloudx
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"github.com/ory/cli/cmd/cloudx/client"
@@ -13,7 +11,7 @@ import (
 func NewDeleteCmd(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete",
-		Short: fmt.Sprintf("Delete resources"),
+		Short: "Delete resources",
 	}
 
 	cmd.AddCommand(identity.NewDeleteIdentityCmd(parent))

--- a/cmd/cloudx/e2e/root.go
+++ b/cmd/cloudx/e2e/root.go
@@ -6,7 +6,6 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
-
 	"github.com/spf13/cobra"
 
 	"github.com/ory/cli/cmd/cloudx/proxy"

--- a/cmd/cloudx/get.go
+++ b/cmd/cloudx/get.go
@@ -1,21 +1,18 @@
 package cloudx
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"github.com/ory/cli/cmd/cloudx/client"
 	"github.com/ory/cli/cmd/cloudx/identity"
 	"github.com/ory/cli/cmd/cloudx/project"
-
 	"github.com/ory/x/cmdx"
 )
 
 func NewGetCmd(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get",
-		Short: fmt.Sprintf("Get a resource"),
+		Short: "Get a resource",
 	}
 
 	cmd.AddCommand(

--- a/cmd/cloudx/identity/delete_test.go
+++ b/cmd/cloudx/identity/delete_test.go
@@ -3,13 +3,12 @@ package identity_test
 import (
 	"testing"
 
-	"github.com/ory/cli/cmd/cloudx/testhelpers"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 
 	"github.com/ory/cli/cmd/cloudx/client"
+	"github.com/ory/cli/cmd/cloudx/testhelpers"
 )
 
 func TestDeleteIdentity(t *testing.T) {

--- a/cmd/cloudx/identity/main_test.go
+++ b/cmd/cloudx/identity/main_test.go
@@ -3,9 +3,8 @@ package identity_test
 import (
 	"testing"
 
-	"github.com/ory/x/cmdx"
-
 	"github.com/ory/cli/cmd/cloudx/testhelpers"
+	"github.com/ory/x/cmdx"
 )
 
 var (

--- a/cmd/cloudx/list.go
+++ b/cmd/cloudx/list.go
@@ -1,14 +1,11 @@
 package cloudx
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"github.com/ory/cli/cmd/cloudx/client"
 	"github.com/ory/cli/cmd/cloudx/identity"
 	"github.com/ory/cli/cmd/cloudx/project"
-
 	"github.com/ory/x/cmdx"
 )
 
@@ -16,7 +13,7 @@ func NewListCmd(parent *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   fmt.Sprintf("List resources"),
+		Short:   "List resources",
 	}
 
 	cmd.AddCommand(project.NewListProjectsCmd())

--- a/cmd/cloudx/patch.go
+++ b/cmd/cloudx/patch.go
@@ -1,18 +1,16 @@
 package cloudx
 
 import (
-	"fmt"
+	"github.com/spf13/cobra"
 
 	"github.com/ory/cli/cmd/cloudx/client"
 	"github.com/ory/cli/cmd/cloudx/project"
-
-	"github.com/spf13/cobra"
 )
 
 func NewPatchCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "patch",
-		Short: fmt.Sprintf("Patch resources"),
+		Short: "Patch resources",
 	}
 	client.RegisterConfigFlag(cmd.PersistentFlags())
 	cmd.AddCommand(

--- a/cmd/cloudx/project/create.go
+++ b/cmd/cloudx/project/create.go
@@ -15,7 +15,7 @@ import (
 func NewCreateProjectCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "project",
-		Short: fmt.Sprintf("Create a new Ory Cloud Project"),
+		Short: "Create a new Ory Cloud Project",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			h, err := client.NewCommandHelper(cmd)
 			if err != nil {

--- a/cmd/cloudx/project/get.go
+++ b/cmd/cloudx/project/get.go
@@ -1,20 +1,17 @@
 package project
 
 import (
-	"fmt"
+	"github.com/spf13/cobra"
 
 	"github.com/ory/cli/cmd/cloudx/client"
-
 	"github.com/ory/x/cmdx"
-
-	"github.com/spf13/cobra"
 )
 
 func NewGetProjectCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "project <id>",
 		Args:  cobra.ExactArgs(1),
-		Short: fmt.Sprintf("Get an Ory Cloud project"),
+		Short: "Get an Ory Cloud project",
 		Example: `$ ory get project ecaaa3cb-0730-4ee8-a6df-9553cdfeef89
 
 ID		ecaaa3cb-0730-4ee8-a6df-9553cdfeef89

--- a/cmd/cloudx/project/get_identity_config.go
+++ b/cmd/cloudx/project/get_identity_config.go
@@ -1,10 +1,10 @@
 package project
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/ory/cli/cmd/cloudx/client"
 	"github.com/ory/x/cmdx"
-
-	"github.com/spf13/cobra"
 )
 
 func NewGetKratosConfigCmd() *cobra.Command {

--- a/cmd/cloudx/project/get_permission_config.go
+++ b/cmd/cloudx/project/get_permission_config.go
@@ -1,10 +1,10 @@
 package project
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/ory/cli/cmd/cloudx/client"
 	"github.com/ory/x/cmdx"
-
-	"github.com/spf13/cobra"
 )
 
 func NewGetKetoConfigCmd() *cobra.Command {

--- a/cmd/cloudx/project/get_test.go
+++ b/cmd/cloudx/project/get_test.go
@@ -1,7 +1,6 @@
 package project_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,7 +9,7 @@ import (
 )
 
 func TestGetProject(t *testing.T) {
-	t.Run(fmt.Sprintf("is able to get project"), func(t *testing.T) {
+	t.Run("is able to get project", func(t *testing.T) {
 		stdout, _, err := defaultCmd.Exec(nil, "get", "project", defaultProject, "--format", "json")
 		require.NoError(t, err)
 		assert.Equal(t, defaultProject, gjson.Get(stdout, "id").String())

--- a/cmd/cloudx/project/list.go
+++ b/cmd/cloudx/project/list.go
@@ -1,19 +1,16 @@
 package project
 
 import (
-	"fmt"
-
-	"github.com/ory/cli/cmd/cloudx/client"
-
 	"github.com/spf13/cobra"
 
+	"github.com/ory/cli/cmd/cloudx/client"
 	"github.com/ory/x/cmdx"
 )
 
 func NewListProjectsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "projects",
-		Short: fmt.Sprintf("List your Ory Cloud projects"),
+		Short: "List your Ory Cloud projects",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			h, err := client.NewCommandHelper(cmd)
 			if err != nil {

--- a/cmd/cloudx/project/patch.go
+++ b/cmd/cloudx/project/patch.go
@@ -6,12 +6,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	cloud "github.com/ory/client-go"
-
 	"github.com/ory/cli/cmd/cloudx/client"
-
+	cloud "github.com/ory/client-go"
 	"github.com/ory/x/cmdx"
-
 	"github.com/ory/x/flagx"
 )
 

--- a/cmd/cloudx/project/patch_identity_config.go
+++ b/cmd/cloudx/project/patch_identity_config.go
@@ -4,7 +4,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ory/cli/cmd/cloudx/client"
-
 	"github.com/ory/x/cmdx"
 )
 

--- a/cmd/cloudx/project/patch_permission_config.go
+++ b/cmd/cloudx/project/patch_permission_config.go
@@ -4,7 +4,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ory/cli/cmd/cloudx/client"
-
 	"github.com/ory/x/cmdx"
 )
 

--- a/cmd/cloudx/project/update.go
+++ b/cmd/cloudx/project/update.go
@@ -6,12 +6,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	cloud "github.com/ory/client-go"
-
 	"github.com/ory/cli/cmd/cloudx/client"
-
+	cloud "github.com/ory/client-go"
 	"github.com/ory/x/cmdx"
-
 	"github.com/ory/x/flagx"
 )
 

--- a/cmd/cloudx/project/update_identity_config.go
+++ b/cmd/cloudx/project/update_identity_config.go
@@ -4,7 +4,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ory/cli/cmd/cloudx/client"
-
 	"github.com/ory/x/cmdx"
 )
 

--- a/cmd/cloudx/project/update_permission_config.go
+++ b/cmd/cloudx/project/update_permission_config.go
@@ -4,7 +4,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ory/cli/cmd/cloudx/client"
-
 	"github.com/ory/x/cmdx"
 )
 

--- a/cmd/cloudx/project/update_test.go
+++ b/cmd/cloudx/project/update_test.go
@@ -5,13 +5,11 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/ory/x/assertx"
-
-	"github.com/ory/cli/cmd/cloudx/testhelpers"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ory/cli/cmd/cloudx/testhelpers"
+	"github.com/ory/x/assertx"
 	"github.com/ory/x/cmdx"
 	"github.com/ory/x/snapshotx"
 )

--- a/cmd/cloudx/project/utils.go
+++ b/cmd/cloudx/project/utils.go
@@ -4,11 +4,10 @@ import (
 	"encoding/json"
 
 	"github.com/spf13/cobra"
+	"github.com/tidwall/sjson"
 
 	cloud "github.com/ory/client-go"
 	"github.com/ory/x/cmdx"
-
-	"github.com/tidwall/sjson"
 )
 
 func prefixConfig(prefix string, s []string) []string {

--- a/cmd/cloudx/proxy/cmd_proxy.go
+++ b/cmd/cloudx/proxy/cmd_proxy.go
@@ -7,11 +7,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/ory/x/corsx"
-
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
+	"github.com/ory/x/corsx"
 	"github.com/ory/x/flagx"
 	"github.com/ory/x/stringsx"
 )
@@ -275,7 +274,7 @@ func printDeprecations(cmd *cobra.Command, target string) {
 		for k, v := range found {
 			values = append(values, fmt.Sprintf("%s=%s", k, v))
 		}
-		sort.Sort(sort.StringSlice(values))
+		sort.Strings(values)
 
 		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Attention! We found multiple sources for the project slug. Please clean up environment variables and flags to ensure that the correct value is being used. Found values:\n\n\t%s\n\nOrder of precedence is: %s > %s > %s > --%s\nDecided to use value: %s\n\n", strings.Join(values, "\n\t"), envVarSlug, envVarSDK, envVarKratos, ProjectFlag, target)
 	}

--- a/cmd/cloudx/proxy/cmd_proxy.go
+++ b/cmd/cloudx/proxy/cmd_proxy.go
@@ -2,11 +2,12 @@ package proxy
 
 import (
 	"fmt"
-	"github.com/ory/x/corsx"
 	"net/url"
 	"os"
 	"sort"
 	"strings"
+
+	"github.com/ory/x/corsx"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"

--- a/cmd/cloudx/proxy/cmd_tunnel.go
+++ b/cmd/cloudx/proxy/cmd_tunnel.go
@@ -4,19 +4,17 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/ory/x/corsx"
-
-	"github.com/ory/x/stringsx"
-
 	"github.com/spf13/cobra"
 
+	"github.com/ory/x/corsx"
 	"github.com/ory/x/flagx"
+	"github.com/ory/x/stringsx"
 )
 
 func NewTunnelCommand(self string, version string) *cobra.Command {
 	proxyCmd := &cobra.Command{
 		Use:   "tunnel application-url [tunnel-url]",
-		Short: fmt.Sprintf("Tunnel Ory on a subdomain of your app or a separate port your app's domain"),
+		Short: "Tunnel Ory on a subdomain of your app or a separate port your app's domain",
 		Args:  cobra.RangeArgs(1, 2),
 		Example: fmt.Sprintf(`%[1]s tunnel http://localhost:3000 --dev
 %[1]s tunnel https://app.example.com \

--- a/cmd/cloudx/proxy/proxy.go
+++ b/cmd/cloudx/proxy/proxy.go
@@ -13,15 +13,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/rs/cors"
-
-	"github.com/ory/x/corsx"
-
-	"github.com/ory/x/proxy"
-
 	"github.com/gofrs/uuid/v3"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/pkg/errors"
+	"github.com/rs/cors"
 	"github.com/spf13/cobra"
 	"github.com/square/go-jose/v3"
 	"github.com/square/go-jose/v3/jwt"
@@ -30,9 +25,11 @@ import (
 
 	"github.com/ory/graceful"
 	"github.com/ory/herodot"
+	"github.com/ory/x/corsx"
 	"github.com/ory/x/httpx"
 	"github.com/ory/x/jwksx"
 	"github.com/ory/x/logrusx"
+	"github.com/ory/x/proxy"
 	"github.com/ory/x/urlx"
 )
 

--- a/cmd/cloudx/testhelpers/testhelpers.go
+++ b/cmd/cloudx/testhelpers/testhelpers.go
@@ -96,7 +96,7 @@ func ConfigAwareCmd(configDir string) *cmdx.CommandExecuter {
 }
 
 func ConfigPasswordAwareCmd(configDir, password string) *cmdx.CommandExecuter {
-	ctx := client.ContextWithClient(context.WithValue(context.Background(), client.PasswordReader, func() ([]byte, error) {
+	ctx := client.ContextWithClient(context.WithValue(context.Background(), client.PasswordReader{}, func() ([]byte, error) {
 		return []byte(password), nil
 	}))
 	return &cmdx.CommandExecuter{
@@ -134,7 +134,7 @@ func RegisterAccount(t require.TestingT, configDir string) (email, password stri
 		New: func() *cobra.Command {
 			return cloudx.NewRootCommand(new(cobra.Command), "", "")
 		},
-		Ctx: context.WithValue(context.Background(), client.PasswordReader, func() ([]byte, error) {
+		Ctx: context.WithValue(context.Background(), client.PasswordReader{}, func() ([]byte, error) {
 			return []byte(password), nil
 		}),
 		PersistentArgs: []string{"--" + client.ConfigFlag, configDir},

--- a/cmd/cloudx/update.go
+++ b/cmd/cloudx/update.go
@@ -1,8 +1,6 @@
 package cloudx
 
 import (
-	"fmt"
-
 	"github.com/ory/cli/cmd/cloudx/client"
 	"github.com/ory/cli/cmd/cloudx/project"
 
@@ -12,7 +10,7 @@ import (
 func NewUpdateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update",
-		Short: fmt.Sprintf("Update resources"),
+		Short: "Update resources",
 	}
 	cmd.AddCommand(
 		project.NewProjectsUpdateCmd(),

--- a/cmd/dev/ci/deps/url.go
+++ b/cmd/dev/ci/deps/url.go
@@ -64,7 +64,6 @@ type ArchitectureMapping struct {
 type OsMapping struct {
 	Darwin string `yaml:"darwin"`
 	Linux  string `yaml:"linux"`
-	ready  bool
 }
 
 func (c *Component) String() string {
@@ -72,7 +71,7 @@ func (c *Component) String() string {
 	if err != nil {
 		log.Fatalf("error: %v", err)
 	}
-	return fmt.Sprintf("%s", string(d))
+	return string(d)
 }
 
 func (c *Component) getComponentFromConfig(configFilePath string) error {

--- a/cmd/dev/ci/github/env.go
+++ b/cmd/dev/ci/github/env.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	"github.com/ory/cli/cmd/pkg"
 )
@@ -39,9 +41,10 @@ $ source $(ory dev ci github env)`,
 		fmt.Printf("export GITHUB_ORG=%s\n", repo[0])
 		fmt.Printf("export GITHUB_REPO=%s\n", repo[1])
 
+		caser := cases.Title(language.AmericanEnglish)
 		fmt.Printf("export SWAGGER_APP_NAME=%s_%s\n",
-			strings.Title(strings.ToLower(repo[0])),
-			strings.Title(strings.ToLower(repo[1])),
+			caser.String(strings.ToLower(repo[0])),
+			caser.String(strings.ToLower(repo[1])),
 		)
 
 		if ignorePkgs := strings.Split(os.Getenv("SWAGGER_SPEC_IGNORE_PKGS"), ","); len(ignorePkgs) > 0 {

--- a/cmd/dev/ci/main.go
+++ b/cmd/dev/ci/main.go
@@ -4,7 +4,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ory/cli/cmd/dev/ci/deps"
-
 	"github.com/ory/cli/cmd/dev/ci/github"
 	"github.com/ory/cli/cmd/dev/ci/monorepo"
 	"github.com/ory/cli/cmd/dev/ci/orbs"

--- a/cmd/dev/ci/monorepo/components.go
+++ b/cmd/dev/ci/monorepo/components.go
@@ -88,22 +88,6 @@ func getChangedComponents(graph *ComponentGraph) []*Component {
 	return changedComponents
 }
 
-func getChangedComponentIDs(graph *ComponentGraph) []string {
-	var changedComponentIds []string
-	for _, changedComponent := range getChangedComponents(graph) {
-		changedComponentIds = append(changedComponentIds, changedComponent.ID)
-	}
-	return changedComponentIds
-}
-
-func getAffectedComponentIDs(graph *ComponentGraph) []string {
-	var affectedComponentIds []string
-	for _, affectedComponent := range getAffectedComponents(graph) {
-		affectedComponentIds = append(affectedComponentIds, affectedComponent.ID)
-	}
-	return affectedComponentIds
-}
-
 func getAffectedComponents(graph *ComponentGraph) []*Component {
 	changedComponents := getChangedComponents(graph)
 

--- a/cmd/dev/ci/monorepo/components.go
+++ b/cmd/dev/ci/monorepo/components.go
@@ -20,7 +20,7 @@ var components = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 
 		var graph ComponentGraph
-		graph.getComponentGraph(rootDirectory)
+		_, _ = graph.getComponentGraph(rootDirectory)
 
 		switch componentMode {
 		case "affected":

--- a/cmd/dev/ci/monorepo/components.go
+++ b/cmd/dev/ci/monorepo/components.go
@@ -155,10 +155,6 @@ func (component *Component) isAffected(graph *ComponentGraph) bool {
 	return false
 }
 
-func (component *Component) isInvolved(graph *ComponentGraph) bool {
-	return component.isChanged(graph) || component.isAffected(graph)
-}
-
 func getCurrentComponent() (*Component, error) {
 	pwd, err := os.Getwd()
 	if err != nil {

--- a/cmd/dev/ci/monorepo/depgraph_test.go
+++ b/cmd/dev/ci/monorepo/depgraph_test.go
@@ -26,7 +26,7 @@ func TestMonorepoCirclular(t *testing.T) {
 func TestMonorepoWorking(t *testing.T) {
 	var graph ComponentGraph
 
-	graph.getComponentGraph("test/working")
+	_, _ = graph.getComponentGraph("test/working")
 	graph.displayGraph()
 
 	resolved, err := graph.resolveGraph()

--- a/cmd/dev/ci/monorepo/main.go
+++ b/cmd/dev/ci/monorepo/main.go
@@ -21,10 +21,6 @@ func isPR() bool {
 	return len(pr) > 0
 }
 
-func isMaster() bool {
-	return branch == "master"
-}
-
 func init() {
 	Main.PersistentFlags().StringVarP(&rootDirectory, "root", "r", ".", "Root directory to be used to traverse and search for dependency configurations.")
 	Main.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Verbose output")

--- a/cmd/dev/ci/orbs/bump.go
+++ b/cmd/dev/ci/orbs/bump.go
@@ -8,9 +8,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/ory/x/flagx"
-
 	"github.com/ory/cli/cmd/pkg"
+	"github.com/ory/x/flagx"
 )
 
 var orbs = []string{

--- a/cmd/dev/headers/comments/file_type_test.go
+++ b/cmd/dev/headers/comments/file_type_test.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ory/cli/cmd/dev/headers/comments"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ory/cli/cmd/dev/headers/comments"
 )
 
 func TestContainsFileType(t *testing.T) {

--- a/cmd/dev/headers/comments/files_test.go
+++ b/cmd/dev/headers/comments/files_test.go
@@ -5,8 +5,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ory/cli/cmd/dev/headers/comments"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ory/cli/cmd/dev/headers/comments"
 )
 
 func TestFileContentWithoutHeader_knownFile(t *testing.T) {

--- a/cmd/dev/headers/copy.go
+++ b/cmd/dev/headers/copy.go
@@ -40,8 +40,7 @@ func CopyFile(src, dst string) error {
 		dstPath = filepath.Join(dst, filepath.Base(src))
 	}
 	headerText := fmt.Sprintf(COPY_HEADER_TEMPLATE, ROOT_PATH+src)
-	comments.WriteFileWithHeader(dstPath, headerText, string(body))
-	return nil
+	return comments.WriteFileWithHeader(dstPath, headerText, string(body))
 }
 
 // Header-aware equivalent of the Unix `cp -r` command.
@@ -62,7 +61,7 @@ func CopyFiles(src, dst string) error {
 	extraPath := ""
 	if hasDst {
 		srcLast := filepath.Base(src)
-		os.MkdirAll(filepath.Join(dst, srcLast), 0744)
+		_ = os.MkdirAll(filepath.Join(dst, srcLast), 0744)
 		extraPath = srcLast
 	}
 	return filepath.Walk(src, func(path string, info fs.FileInfo, err error) error {

--- a/cmd/dev/headers/copy.go
+++ b/cmd/dev/headers/copy.go
@@ -11,8 +11,9 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/ory/cli/cmd/dev/headers/comments"
 	"github.com/spf13/cobra"
+
+	"github.com/ory/cli/cmd/dev/headers/comments"
 )
 
 // template for the header

--- a/cmd/dev/headers/license.go
+++ b/cmd/dev/headers/license.go
@@ -8,9 +8,10 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/ory/cli/cmd/dev/headers/comments"
 	goGitIgnore "github.com/sabhiram/go-gitignore"
 	"github.com/spf13/cobra"
+
+	"github.com/ory/cli/cmd/dev/headers/comments"
 )
 
 // LICENSE defines the full license text.

--- a/cmd/dev/main.go
+++ b/cmd/dev/main.go
@@ -1,6 +1,8 @@
 package dev
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/ory/cli/cmd/dev/ci"
 	"github.com/ory/cli/cmd/dev/headers"
 	"github.com/ory/cli/cmd/dev/markdown"
@@ -10,7 +12,6 @@ import (
 	"github.com/ory/cli/cmd/dev/release"
 	"github.com/ory/cli/cmd/dev/schema"
 	"github.com/ory/cli/cmd/dev/swagger"
-	"github.com/spf13/cobra"
 )
 
 var Main = &cobra.Command{

--- a/cmd/dev/main.go
+++ b/cmd/dev/main.go
@@ -3,11 +3,10 @@ package dev
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/ory/cli/cmd/dev/openapi"
-
 	"github.com/ory/cli/cmd/dev/ci"
 	"github.com/ory/cli/cmd/dev/markdown"
 	"github.com/ory/cli/cmd/dev/newsletter"
+	"github.com/ory/cli/cmd/dev/openapi"
 	"github.com/ory/cli/cmd/dev/pop"
 	"github.com/ory/cli/cmd/dev/release"
 	"github.com/ory/cli/cmd/dev/schema"

--- a/cmd/dev/newsletter/draft.go
+++ b/cmd/dev/newsletter/draft.go
@@ -8,17 +8,15 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ory/cli/view"
+	"github.com/spf13/cobra"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
-	"github.com/spf13/cobra"
-
+	"github.com/ory/cli/cmd/pkg"
+	"github.com/ory/cli/view"
 	"github.com/ory/gochimp3"
 	_ "github.com/ory/x/cmdx"
 	"github.com/ory/x/flagx"
-
-	"github.com/ory/cli/cmd/pkg"
 )
 
 var draft = &cobra.Command{

--- a/cmd/dev/newsletter/draft.go
+++ b/cmd/dev/newsletter/draft.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 
 	"github.com/ory/cli/view"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	"github.com/spf13/cobra"
 
@@ -83,7 +85,8 @@ func Draft(listID string, segmentID int, tagMessageRaw, changelogRaw []byte) (*g
 		repoName = pkg.MustGetEnv("CIRCLE_PROJECT_REPONAME")
 	}
 
-	projectName := "ORY " + strings.Title(strings.ToLower(repoName))
+	caser := cases.Title(language.AmericanEnglish)
+	projectName := "ORY " + caser.String(strings.ToLower(repoName))
 
 	changelog := renderMarkdown(changelogRaw)
 	tagMessage := renderMarkdown(tagMessageRaw)

--- a/cmd/dev/newsletter/pkg.go
+++ b/cmd/dev/newsletter/pkg.go
@@ -13,20 +13,16 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
-
-	"github.com/hashicorp/go-retryablehttp"
-
-	"github.com/gomarkdown/markdown/ast"
-
 	"github.com/gomarkdown/markdown"
+	"github.com/gomarkdown/markdown/ast"
 	"github.com/gomarkdown/markdown/html"
 	"github.com/gomarkdown/markdown/parser"
-
-	"github.com/ory/gochimp3"
-	"github.com/ory/x/httpx"
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/pkg/errors"
 
 	"github.com/ory/cli/cmd/pkg"
+	"github.com/ory/gochimp3"
+	"github.com/ory/x/httpx"
 )
 
 var defaultRenderer = html.NewRenderer(html.RendererOptions{

--- a/cmd/dev/newsletter/render_test.go
+++ b/cmd/dev/newsletter/render_test.go
@@ -32,6 +32,7 @@ func TestRenderMarkdownLong(t *testing.T) {
 	require.NoError(t, err)
 
 	tmplRaw, err := ioutil.ReadFile("../../../view/mail-body.html")
+	require.NoError(t, err)
 	tmpl, err := template.New("view").Parse(string(tmplRaw))
 	require.NoError(t, err)
 	var body bytes.Buffer

--- a/cmd/dev/newsletter/send.go
+++ b/cmd/dev/newsletter/send.go
@@ -5,10 +5,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/ory/cli/cmd/pkg"
 	"github.com/ory/gochimp3"
 	"github.com/ory/x/flagx"
-
-	"github.com/ory/cli/cmd/pkg"
 )
 
 var send = &cobra.Command{

--- a/cmd/dev/openapi/migrate.go
+++ b/cmd/dev/openapi/migrate.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ory/cli/cmd/pkg"
-
 	"github.com/ory/x/flagx"
 )
 

--- a/cmd/dev/pop/migration/fizzx/migrator.go
+++ b/cmd/dev/pop/migration/fizzx/migrator.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"text/tabwriter"
 	"time"
@@ -18,8 +17,6 @@ import (
 
 	"github.com/pkg/errors"
 )
-
-var mrx = regexp.MustCompile(`^(\d+)_([^.]+)(\.[a-z0-9]+)?\.(up|down)\.(sql|fizz)$`)
 
 type MigrationTuple struct {
 	ID        string

--- a/cmd/dev/pop/migration/render.go
+++ b/cmd/dev/pop/migration/render.go
@@ -8,24 +8,20 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/ory/x/logrusx"
-
-	"github.com/ory/x/randx"
-	"github.com/ory/x/stringslice"
-
+	"github.com/avast/retry-go"
 	"github.com/go-sql-driver/mysql"
 	"github.com/gobuffalo/pop/v5"
 	"github.com/gobuffalo/pop/v5/logging"
 	_ "github.com/jackc/pgx/v4/stdlib"
 	"github.com/spf13/cobra"
 
-	"github.com/ory/x/flagx"
-	"github.com/ory/x/sqlcon/dockertest"
-
-	"github.com/avast/retry-go"
-
 	"github.com/ory/cli/cmd/dev/pop/migration/fizzx"
 	"github.com/ory/cli/cmd/pkg"
+	"github.com/ory/x/flagx"
+	"github.com/ory/x/logrusx"
+	"github.com/ory/x/randx"
+	"github.com/ory/x/sqlcon/dockertest"
+	"github.com/ory/x/stringslice"
 )
 
 var render = &cobra.Command{

--- a/cmd/dev/release/compile.go
+++ b/cmd/dev/release/compile.go
@@ -7,9 +7,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/ory/x/flagx"
-
 	"github.com/ory/cli/cmd/pkg"
+	"github.com/ory/x/flagx"
 )
 
 var compile = &cobra.Command{

--- a/cmd/dev/release/notify/draft.go
+++ b/cmd/dev/release/notify/draft.go
@@ -12,10 +12,9 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/spf13/cobra"
 
-	"github.com/ory/x/flagx"
-
 	"github.com/ory/cli/cmd/dev/newsletter"
 	"github.com/ory/cli/cmd/pkg"
+	"github.com/ory/x/flagx"
 )
 
 var gitCommitMessageBaseRegex = regexp.MustCompile("(?im)^" + pkg.GitCommitMessagePreviousVersion + "\\sv([0-9a-zA-Z\\-\\._]+)$")

--- a/cmd/dev/release/notify/send.go
+++ b/cmd/dev/release/notify/send.go
@@ -3,9 +3,8 @@ package notify
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/ory/x/flagx"
-
 	"github.com/ory/cli/cmd/dev/newsletter"
+	"github.com/ory/x/flagx"
 )
 
 var send = &cobra.Command{

--- a/cmd/dev/release/publish.go
+++ b/cmd/dev/release/publish.go
@@ -8,13 +8,11 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
-
 	"github.com/spf13/cobra"
 
+	"github.com/ory/cli/cmd/pkg"
 	"github.com/ory/x/flagx"
 	"github.com/ory/x/stringslice"
-
-	"github.com/ory/cli/cmd/pkg"
 )
 
 var isTestRelease = regexp.MustCompile(`^(([a-zA-Z0-9\.\-]+\.)|)pre\.[0-9]+$`)

--- a/cmd/dev/release/publish.go
+++ b/cmd/dev/release/publish.go
@@ -17,7 +17,7 @@ import (
 	"github.com/ory/cli/cmd/pkg"
 )
 
-var isTestRelease = regexp.MustCompile("^(([a-zA-Z0-9\\.\\-]+\\.)|)pre\\.[0-9]+$")
+var isTestRelease = regexp.MustCompile(`^(([a-zA-Z0-9\.\-]+\.)|)pre\.[0-9]+$`)
 
 var publish = &cobra.Command{
 	Use:   "publish [version]",

--- a/cmd/dev/schema/render_version.go
+++ b/cmd/dev/schema/render_version.go
@@ -28,7 +28,7 @@ var RenderVersion = &cobra.Command{
 	Run:   addVersionToSchema,
 }
 
-var preReleaseVersion = regexp.MustCompile(".*[-.]pre\\.")
+var preReleaseVersion = regexp.MustCompile(`.*[-.]pre\.`)
 
 func addVersionToSchema(cmd *cobra.Command, args []string) {
 	const destFile = ".schema/version.schema.json"

--- a/cmd/dev/schema/render_version.go
+++ b/cmd/dev/schema/render_version.go
@@ -11,17 +11,14 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/ory/cli/spec"
-	"github.com/ory/jsonschema/v3/httploader"
-	"github.com/ory/x/httpx"
-
-	"github.com/ory/x/jsonschemax"
-
 	"github.com/spf13/cobra"
 
 	"github.com/ory/cli/cmd/pkg"
+	"github.com/ory/cli/spec"
 	"github.com/ory/jsonschema/v3"
-	_ "github.com/ory/jsonschema/v3/httploader"
+	"github.com/ory/jsonschema/v3/httploader"
+	"github.com/ory/x/httpx"
+	"github.com/ory/x/jsonschemax"
 )
 
 var RenderVersion = &cobra.Command{

--- a/cmd/dev/schema/render_version_test.go
+++ b/cmd/dev/schema/render_version_test.go
@@ -59,7 +59,8 @@ func TestAddVersionToSchema(t *testing.T) {
 		require.NoError(t, os.Chdir(testDir))
 
 		cmd := new(cobra.Command)
-		cmd.ExecuteContext(context.Background())
+		err = cmd.ExecuteContext(context.Background())
+		require.NoError(t, err)
 		addVersionToSchema(cmd, []string{"hydra", "v1.0.0", ".schema/config.schema.json"})
 
 		require.NoError(t, os.Chdir(wd))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,15 +5,14 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/ory/cli/cmd/cloudx/client"
-	"github.com/ory/cli/cmd/cloudx/proxy"
-	"github.com/ory/kratos/cmd/jsonnet"
-
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/ory/cli/buildinfo"
 	"github.com/ory/cli/cmd/cloudx"
+	"github.com/ory/cli/cmd/cloudx/client"
+	"github.com/ory/cli/cmd/cloudx/proxy"
+	"github.com/ory/kratos/cmd/jsonnet"
 	"github.com/ory/x/cmdx"
 )
 


### PR DESCRIPTION
I noticed that golangci-lint doesn't install properly on my Debian system so here comes a fix together with an update. I'm also running the linter on CI now.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added necessary documentation within the code base (if
      appropriate).
