### PR TITLE
fix: no license headers in YML files

### DIFF
--- a/cmd/dev/headers/license.go
+++ b/cmd/dev/headers/license.go
@@ -20,7 +20,7 @@ const LICENSE_TEMPLATE = "Copyright © %d Ory Corp Inc."
 const LICENSE_TOKEN = "Copyright ©"
 
 // file types that we don't want to add license headers to
-var noLicenseHeadersFor = []comments.FileType{"md"}
+var noLicenseHeadersFor = []comments.FileType{"md", "yml", "yaml"}
 
 // addLicenses adds or updates the Ory license header in all files within the given directory.
 func AddLicenses(dir string, year int) error {

--- a/cmd/dev/headers/license_test.go
+++ b/cmd/dev/headers/license_test.go
@@ -59,8 +59,8 @@ func TestShouldAddLicense(t *testing.T) {
 		"x.rs":   true,
 		"x.ts":   true,
 		"x.vue":  true,
-		"x.yml":  false,
-		"x.yaml": false,
+		"x.yml":  false, // data is not protected by copyright law
+		"x.yaml": false, // data is not protected by copyright law
 	}
 	for give, want := range tests {
 		t.Run(fmt.Sprintf("%s -> %t", give, want), func(t *testing.T) {

--- a/cmd/dev/headers/license_test.go
+++ b/cmd/dev/headers/license_test.go
@@ -25,6 +25,7 @@ func TestAddLicenses(t *testing.T) {
 	dir.CreateFile("typescript.ts", "const a = 1\nconst b = 2\n")
 	dir.CreateFile("vue.vue", "<template>\n<Header />")
 	dir.CreateFile("yaml.yml", "one: two\nalpha: beta")
+	dir.CreateFile("yaml.yaml", "one: two\nalpha: beta")
 	err := AddLicenses(dir.Path, 2022)
 	assert.NoError(t, err)
 	assert.Equal(t, "// Copyright © 2022 Ory Corp Inc.\n\nusing System;\n\nnamespace Foo.Bar {\n", dir.Content("c-sharp.cs"))
@@ -40,7 +41,8 @@ func TestAddLicenses(t *testing.T) {
 	assert.Equal(t, "// Copyright © 2022 Ory Corp Inc.\n\nlet a = 1;\nlet mut b = 2;\n", dir.Content("rust.rs"))
 	assert.Equal(t, "// Copyright © 2022 Ory Corp Inc.\n\nconst a = 1\nconst b = 2\n", dir.Content("typescript.ts"))
 	assert.Equal(t, "<!-- Copyright © 2022 Ory Corp Inc. -->\n\n<template>\n<Header />", dir.Content("vue.vue"))
-	assert.Equal(t, "# Copyright © 2022 Ory Corp Inc.\n\none: two\nalpha: beta", dir.Content("yaml.yml"))
+	assert.Equal(t, "one: two\nalpha: beta", dir.Content("yaml.yml"))
+	assert.Equal(t, "one: two\nalpha: beta", dir.Content("yaml.yaml"))
 }
 
 func TestShouldAddLicense(t *testing.T) {
@@ -57,7 +59,8 @@ func TestShouldAddLicense(t *testing.T) {
 		"x.rs":   true,
 		"x.ts":   true,
 		"x.vue":  true,
-		"x.yml":  true,
+		"x.yml":  false,
+		"x.yaml": false,
 	}
 	for give, want := range tests {
 		t.Run(fmt.Sprintf("%s -> %t", give, want), func(t *testing.T) {


### PR DESCRIPTION
Data is not protected by copyright law. YML files contain data. JSON also doesn't allow comments so this is more consistent.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).
