### PR TITLE
chore: folders without license headers

### DIFF
--- a/cmd/dev/headers/license.go
+++ b/cmd/dev/headers/license.go
@@ -25,8 +25,7 @@ const LICENSE_TOKEN = "Copyright ©"
 // file types that we don't want to add license headers to
 var noLicenseHeadersFor = []comments.FileType{"md", "yml", "yaml"}
 
-// AddLicenses adds or updates the Ory license header in all applicable files within the given directory
-// except if in the given list of directories to exclude.
+// AddLicenses adds or updates the Ory license header in all applicable files within the given directory.
 func AddLicenses(dir string, year int, exclude []string) error {
 	licenseText := fmt.Sprintf(LICENSE_TEMPLATE, year)
 	gitIgnore, _ := goGitIgnore.CompileIgnoreFile(filepath.Join(dir, ".gitignore"))

--- a/cmd/dev/headers/license.go
+++ b/cmd/dev/headers/license.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/fs"
 	"path/filepath"
+	"strings"
 	"time"
 
 	goGitIgnore "github.com/sabhiram/go-gitignore"
@@ -23,8 +24,9 @@ const LICENSE_TOKEN = "Copyright ©"
 // file types that we don't want to add license headers to
 var noLicenseHeadersFor = []comments.FileType{"md", "yml", "yaml"}
 
-// addLicenses adds or updates the Ory license header in all files within the given directory.
-func AddLicenses(dir string, year int) error {
+// AddLicenses adds or updates the Ory license header in all applicable files within the given directory
+// except if in the given list of directories to exclude.
+func AddLicenses(dir string, year int, exclude []string) error {
 	licenseText := fmt.Sprintf(LICENSE_TEMPLATE, year)
 	gitIgnore, _ := goGitIgnore.CompileIgnoreFile(filepath.Join(dir, ".gitignore"))
 	return filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
@@ -40,7 +42,10 @@ func AddLicenses(dir string, year int) error {
 		if !comments.SupportsFile(path) {
 			return nil
 		}
-		if !shouldAddLicense(path) {
+		if !fileTypeIsLicensed(path) {
+			return nil
+		}
+		if isInExcludedFolder(path, exclude) {
 			return nil
 		}
 		contentNoHeader, err := comments.FileContentWithoutHeader(path, LICENSE_TOKEN)
@@ -51,21 +56,38 @@ func AddLicenses(dir string, year int) error {
 	})
 }
 
+// isInExcludedFolder indicates whether the given path exists within the given list of folders
+func isInExcludedFolder(path string, exclude []string) bool {
+	for _, e := range exclude {
+		if strings.HasPrefix(path, e) {
+			return true
+		}
+	}
+	return false
+}
+
 // indicates whether this tool is configured to add a license header to the file with the given path
-func shouldAddLicense(path string) bool {
+func fileTypeIsLicensed(path string) bool {
 	return !comments.ContainsFileType(noLicenseHeadersFor, comments.GetFileType(path))
 }
 
 var copyright = &cobra.Command{
 	Use:   "license",
 	Short: "Adds the license header to all known files in the current directory",
-	Args:  cobra.ExactArgs(1),
+	Long: `Adds the license header to all known files in the current directory.
+
+Does not add the license header to git-ignored files.`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		year, _, _ := time.Now().Date()
-		return AddLicenses(args[0], year)
+		return AddLicenses(args[0], year, exclude)
 	},
 }
 
 func init() {
 	Main.AddCommand(copyright)
+	copyright.Flags().StringSliceVarP(&exclude, "exclude", "e", []string{}, "folders to exclude")
 }
+
+// contains the folders to exclude
+var exclude []string

--- a/cmd/dev/headers/license.go
+++ b/cmd/dev/headers/license.go
@@ -89,7 +89,7 @@ Does not add the license header to git-ignored files.`,
 
 func init() {
 	Main.AddCommand(copyright)
-	copyright.Flags().StringSliceVarP(&exclude, "exclude", "e", []string{}, "folders to exclude")
+	copyright.Flags().StringSliceVarP(&exclude, "exclude", "e", []string{}, "folders to exclude, provide comma-separated values or multiple instances of this flag")
 }
 
 // contains the folders to exclude

--- a/cmd/dev/headers/license.go
+++ b/cmd/dev/headers/license.go
@@ -5,6 +5,7 @@ package headers
 import (
 	"fmt"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -77,10 +78,13 @@ var copyright = &cobra.Command{
 	Long: `Adds the license header to all known files in the current directory.
 
 Does not add the license header to git-ignored files.`,
-	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("cannot determine the current directory: %w", err)
+		}
 		year, _, _ := time.Now().Date()
-		return AddLicenses(args[0], year, exclude)
+		return AddLicenses(cwd, year, exclude)
 	},
 }
 

--- a/cmd/dev/headers/license.go
+++ b/cmd/dev/headers/license.go
@@ -83,6 +83,9 @@ Does not add the license header to git-ignored files.`,
 			return fmt.Errorf("cannot determine the current directory: %w", err)
 		}
 		year, _, _ := time.Now().Date()
+		for e, excluded := range exclude {
+			exclude[e] = filepath.Join(cwd, excluded)
+		}
 		return AddLicenses(cwd, year, exclude)
 	},
 }

--- a/cmd/dev/headers/license_test.go
+++ b/cmd/dev/headers/license_test.go
@@ -26,7 +26,7 @@ func TestAddLicenses(t *testing.T) {
 	dir.CreateFile("vue.vue", "<template>\n<Header />")
 	dir.CreateFile("yaml.yml", "one: two\nalpha: beta")
 	dir.CreateFile("yaml.yaml", "one: two\nalpha: beta")
-	err := AddLicenses(dir.Path, 2022)
+	err := AddLicenses(dir.Path, 2022, []string{})
 	assert.NoError(t, err)
 	assert.Equal(t, "// Copyright © 2022 Ory Corp\n\nusing System;\n\nnamespace Foo.Bar {\n", dir.Content("c-sharp.cs"))
 	assert.Equal(t, "// Copyright © 2022 Ory Corp\n\nint a = 1;\nint b = 2;", dir.Content("dart.dart"))
@@ -43,6 +43,21 @@ func TestAddLicenses(t *testing.T) {
 	assert.Equal(t, "<!-- Copyright © 2022 Ory Corp -->\n\n<template>\n<Header />", dir.Content("vue.vue"))
 	assert.Equal(t, "one: two\nalpha: beta", dir.Content("yaml.yml"))
 	assert.Equal(t, "one: two\nalpha: beta", dir.Content("yaml.yaml"))
+}
+
+func TestIsExcluded(t *testing.T) {
+	tests := map[string]bool{
+		"foo.md":                                false,
+		"foo/bar/baz.md":                        false,
+		"internal/httpclient/README.md":         true,
+		"internal/httpclient/foo/bar/README.md": true,
+		"generated/README.md":                   true,
+		"generated/foo/bar/README.md":           true,
+	}
+	exclude := []string{"internal/httpclient", "generated/"}
+	for give, want := range tests {
+		assert.Equal(t, want, isInExcludedFolder(give, exclude), "%q -> %t", give, want)
+	}
 }
 
 func TestShouldAddLicense(t *testing.T) {
@@ -64,7 +79,7 @@ func TestShouldAddLicense(t *testing.T) {
 	}
 	for give, want := range tests {
 		t.Run(fmt.Sprintf("%s -> %t", give, want), func(t *testing.T) {
-			assert.Equal(t, want, shouldAddLicense(give))
+			assert.Equal(t, want, fileTypeIsLicensed(give))
 		})
 	}
 }

--- a/cmd/dev/headers/license_test.go
+++ b/cmd/dev/headers/license_test.go
@@ -46,6 +46,7 @@ func TestAddLicenses(t *testing.T) {
 }
 
 func TestIsExcluded(t *testing.T) {
+	exclude := []string{"internal/httpclient", "generated/"}
 	tests := map[string]bool{
 		"foo.md":                                false,
 		"foo/bar/baz.md":                        false,
@@ -54,7 +55,6 @@ func TestIsExcluded(t *testing.T) {
 		"generated/README.md":                   true,
 		"generated/foo/bar/README.md":           true,
 	}
-	exclude := []string{"internal/httpclient", "generated/"}
 	for give, want := range tests {
 		assert.Equal(t, want, isInExcludedFolder(give, exclude), "%q -> %t", give, want)
 	}


### PR DESCRIPTION
Adds the ability to not add license headers to files in particular folders.


## Related Issue or Design Document

https://github.com/ory/hydra/pull/3216#issuecomment-1242660359

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).
