### PR TITLE
chore: remove double tabs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,51 +19,51 @@ GO_DEPENDENCIES = github.com/ory/go-acc \
 define make-go-dependency
   # go install is responsible for not re-building when the code hasn't changed
   .bin/$(notdir $1): go.mod go.sum Makefile
-		GOBIN=$(PWD)/.bin/ go install $1
+	GOBIN=$(PWD)/.bin/ go install $1
 endef
 $(foreach dep, $(GO_DEPENDENCIES), $(eval $(call make-go-dependency, $(dep))))
 
 .bin/clidoc: Makefile go.mod go.sum cmd
-		go build -tags nodev -o .bin/clidoc ./cmd/clidoc/.
+	go build -tags nodev -o .bin/clidoc ./cmd/clidoc/.
 
 docs/cli: .bin/clidoc
-		curl -o docs/sidebar.json https://raw.githubusercontent.com/ory/docs/master/docs/sidebar.json
-		clidoc .
+	curl -o docs/sidebar.json https://raw.githubusercontent.com/ory/docs/master/docs/sidebar.json
+	clidoc .
 
 .bin/cli: go.mod go.sum Makefile
-		go build -o .bin/cli -tags sqlite github.com/ory/cli
+	go build -o .bin/cli -tags sqlite github.com/ory/cli
 
 .bin/golangci-lint: Makefile
-		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b .bin v1.48.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b .bin v1.48.0
 
 .PHONY: lint
 lint: .bin/golangci-lint
-		.bin/golangci-lint run --timeout=10m ./...
+	.bin/golangci-lint run --timeout=10m ./...
 
 .PHONY: install
 install:
-		GO111MODULE=on go install -tags sqlite .
+	GO111MODULE=on go install -tags sqlite .
 
 .PHONY: test
 test: lint
-		go test -p 1 -tags sqlite -count=1 -failfast ./...
+	go test -p 1 -tags sqlite -count=1 -failfast ./...
 
 # Formats the code
 .PHONY: format
 format: .bin/goimports node_modules
-		goimports -w -local github.com/ory .
-		npm exec -- prettier --write "{**/,}*{.js,.md,.ts}"
+	goimports -w -local github.com/ory .
+	npm exec -- prettier --write "{**/,}*{.js,.md,.ts}"
 
 # Runs tests in short mode, without database adapters
 .PHONY: docker
 docker:
-		docker build -f .docker/Dockerfile-build -t oryd/ory:latest-sqlite .
+	docker build -f .docker/Dockerfile-build -t oryd/ory:latest-sqlite .
 
 
 # Runs tests in short mode, without database adapters
 .PHONY: post-release
 post-release:
-		echo "nothing to do"
+	echo "nothing to do"
 
 node_modules: package-lock.json
 	npm ci

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ GO_DEPENDENCIES = github.com/ory/go-acc \
 define make-go-dependency
   # go install is responsible for not re-building when the code hasn't changed
   .bin/$(notdir $1): go.mod go.sum Makefile
-	GOBIN=$(PWD)/.bin/ go install $1
+		GOBIN=$(PWD)/.bin/ go install $1
 endef
 $(foreach dep, $(GO_DEPENDENCIES), $(eval $(call make-go-dependency, $(dep))))
 


### PR DESCRIPTION
Reduces the indentation of Makefiles from double tabs to single tabs.


## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added the necessary documentation within the code base (if
      appropriate).
