### PR TITLE
feat: [cli/proxy] rewite-host flag

### DIFF
--- a/cmd/cloudx/proxy/cmd_proxy.go
+++ b/cmd/cloudx/proxy/cmd_proxy.go
@@ -210,6 +210,7 @@ An example payload of the JSON Web Token is:
 				defaultRedirectTo: redirectURL,
 				isDev:             flagx.MustGetBool(cmd, DevFlag),
 				isDebug:           flagx.MustGetBool(cmd, DebugFlag),
+				rewriteHost:       flagx.MustGetBool(cmd, RewriteHostFlag),
 				corsOrigins:       origins,
 			}
 
@@ -226,6 +227,7 @@ An example payload of the JSON Web Token is:
 	proxyCmd.Flags().StringSlice(CORSFlag, []string{}, "A list of allowed CORS origins. Wildcards are allowed.")
 	proxyCmd.Flags().Bool(DevFlag, false, "Use this flag when developing locally.")
 	proxyCmd.Flags().Bool(DebugFlag, false, "Use this flag to debug, for example, CORS requests.")
+	proxyCmd.Flags().Bool(RewriteHostFlag, false, "Use this flag to rewrite the host header to the upstream host.")
 
 	client.RegisterConfigFlag(proxyCmd.PersistentFlags())
 	client.RegisterYesFlag(proxyCmd.PersistentFlags())

--- a/cmd/cloudx/proxy/proxy.go
+++ b/cmd/cloudx/proxy/proxy.go
@@ -205,9 +205,7 @@ func run(cmd *cobra.Command, conf *config, version string, name string) error {
 			if r.URL.Host == conf.oryURL.Host {
 				r.URL.Path = strings.TrimPrefix(r.URL.Path, conf.pathPrefix)
 				r.Host = conf.oryURL.Host
-			}
-
-			if conf.rewriteHost {
+			} else if conf.rewriteHost {
 				r.Header.Set("X-Forwarded-Host", r.Host)
 				r.Host = c.UpstreamHost
 			}


### PR DESCRIPTION
This commit enables users to rewrite the Host header to the upstream host, rather than keeping it as the ory proxy Host.

This is especially useful in a scenario where the output of the tunnel routes based on Host.

## (edit) Example scenarii:

- Custom endpoint per-user.
- Multiple service running behind a single load balancer


## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works. (netcat and my staging env says it works)
- [ ] I have added the necessary documentation within the code base (if
      appropriate).
