### PR TITLE
feat: license headers default ignore folders

### DIFF
--- a/cmd/dev/headers/license.go
+++ b/cmd/dev/headers/license.go
@@ -25,6 +25,9 @@ const LICENSE_TOKEN = "Copyright ©"
 // file types that we don't want to add license headers to
 var noLicenseHeadersFor = []comments.FileType{"md", "yml", "yaml"}
 
+// folders that are excluded by default
+var defaultExcludedFolders = []string{"dist", "node_modules", "vendor"}
+
 // AddLicenses adds or updates the Ory license header in all applicable files within the given directory.
 func AddLicenses(dir string, year int, exclude []string) error {
 	licenseText := fmt.Sprintf(LICENSE_TEMPLATE, year)
@@ -45,7 +48,10 @@ func AddLicenses(dir string, year int, exclude []string) error {
 		if !fileTypeIsLicensed(path) {
 			return nil
 		}
-		if isInExcludedFolder(path, exclude) {
+		if isInFolders(path, defaultExcludedFolders) {
+			return nil
+		}
+		if isInFolders(path, exclude) {
 			return nil
 		}
 		contentNoHeader, err := comments.FileContentWithoutHeader(path, LICENSE_TOKEN)
@@ -56,8 +62,8 @@ func AddLicenses(dir string, year int, exclude []string) error {
 	})
 }
 
-// isInExcludedFolder indicates whether the given path exists within the given list of folders
-func isInExcludedFolder(path string, exclude []string) bool {
+// isInFolders indicates whether the given path exists within the given list of folders
+func isInFolders(path string, exclude []string) bool {
 	for _, e := range exclude {
 		if strings.HasPrefix(path, e) {
 			return true

--- a/cmd/dev/headers/license_test.go
+++ b/cmd/dev/headers/license_test.go
@@ -56,7 +56,7 @@ func TestIsExcluded(t *testing.T) {
 		"generated/foo/bar/README.md":           true,
 	}
 	for give, want := range tests {
-		assert.Equal(t, want, isInExcludedFolder(give, exclude), "%q -> %t", give, want)
+		assert.Equal(t, want, isInFolders(give, exclude), "%q -> %t", give, want)
 	}
 }
 


### PR DESCRIPTION
Don't add license headers to files in the node_modules and vendor folders.

## Related Issue or Design Document

https://github.com/ory-corp/general/issues/602

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added the necessary documentation within the code base (if
      appropriate).
