### PR TITLE
fix: license headers ignore files

### DIFF
--- a/cmd/dev/headers/license.go
+++ b/cmd/dev/headers/license.go
@@ -5,7 +5,6 @@ package headers
 import (
 	"fmt"
 	"io/fs"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -84,15 +83,8 @@ var copyright = &cobra.Command{
 
 Does not add the license header to git-ignored files.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cwd, err := os.Getwd()
-		if err != nil {
-			return fmt.Errorf("cannot determine the current directory: %w", err)
-		}
 		year, _, _ := time.Now().Date()
-		for e, excluded := range exclude {
-			exclude[e] = filepath.Join(cwd, excluded)
-		}
-		return AddLicenses(cwd, year, exclude)
+		return AddLicenses(".", year, exclude)
 	},
 }
 


### PR DESCRIPTION
Fix path issues for license headers.

## Related Issue or Design Document

https://github.com/ory-corp/general/issues/602

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added the necessary documentation within the code base (if
      appropriate).
