### PR TITLE
feat: license headers ignore prettier-ignored files

### DIFF
--- a/cmd/dev/headers/license.go
+++ b/cmd/dev/headers/license.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	goGitIgnore "github.com/sabhiram/go-gitignore"
+	ignore "github.com/sabhiram/go-gitignore"
 	"github.com/spf13/cobra"
 
 	"github.com/ory/cli/cmd/dev/headers/comments"
@@ -30,7 +30,8 @@ var defaultExcludedFolders = []string{"dist", "node_modules", "vendor"}
 // AddLicenses adds or updates the Ory license header in all applicable files within the given directory.
 func AddLicenses(dir string, year int, exclude []string) error {
 	licenseText := fmt.Sprintf(LICENSE_TEMPLATE, year)
-	gitIgnore, _ := goGitIgnore.CompileIgnoreFile(filepath.Join(dir, ".gitignore"))
+	gitIgnore, _ := ignore.CompileIgnoreFile(filepath.Join(dir, ".gitignore"))
+	prettierIgnore, _ := ignore.CompileIgnoreFile(filepath.Join(dir, ".prettierignore"))
 	return filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
 			return fmt.Errorf("cannot read directory %q: %w", path, err)
@@ -39,6 +40,9 @@ func AddLicenses(dir string, year int, exclude []string) error {
 			return nil
 		}
 		if gitIgnore != nil && gitIgnore.MatchesPath(info.Name()) {
+			return nil
+		}
+		if prettierIgnore != nil && prettierIgnore.MatchesPath(info.Name()) {
 			return nil
 		}
 		if !comments.SupportsFile(path) {

--- a/cmd/dev/headers/license.go
+++ b/cmd/dev/headers/license.go
@@ -83,9 +83,9 @@ func fileTypeIsLicensed(path string) bool {
 var copyright = &cobra.Command{
 	Use:   "license",
 	Short: "Adds the license header to all known files in the current directory",
-	Long: `Adds the license header to all known files in the current directory.
+	Long: `Adds the license header to all files that need one in the current directory.
 
-Does not add the license header to git-ignored files.`,
+Does not add the license header to files listed in .gitignore and .prettierignore.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		year, _, _ := time.Now().Date()
 		return AddLicenses(".", year, exclude)


### PR DESCRIPTION
Don't add license header to prettier-ignored files.

## Related Issue or Design Document

https://github.com/ory-corp/general/issues/602

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added the necessary documentation within the code base (if
      appropriate).
