### PR TITLE
fix: installation instructions that are compatible with non-bash shells

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is the ORY Command Line Interface (CLI).
 ## Unix (Linux / macOS)
 
 ```shell-session
-$ bash <(curl https://raw.githubusercontent.com/ory/meta/master/install.sh) ory
+$ curl https://raw.githubusercontent.com/ory/meta/master/install.sh | sh
 $ ory help
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is the ORY Command Line Interface (CLI).
 ## Unix (Linux / macOS)
 
 ```shell-session
-$ curl https://raw.githubusercontent.com/ory/meta/master/install.sh | sh
+$ curl https://raw.githubusercontent.com/ory/meta/master/install.sh | sh -s ory
 $ ory help
 ```
 


### PR DESCRIPTION
Other shells like Fish shell cannot execute the existing installation instructions because they rely on Bashisms. This PR introduces a simplified format for Ory CLI that is more compatible with different shells.


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added the necessary documentation within the code base (if
      appropriate).
