### PR TITLE
chore: simplify tests

### DIFF
--- a/cmd/dev/headers/comments/files_test.go
+++ b/cmd/dev/headers/comments/files_test.go
@@ -2,7 +2,6 @@ package comments_test
 
 import (
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,13 +11,8 @@ import (
 
 func TestFileContentWithoutHeader(t *testing.T) {
 	t.Run("known file, copyright header", func(t *testing.T) {
-		give := strings.Trim(`
-// Copyright © 2021 Ory Corp
-// SPDX-License-Identifier: Apache-2.0
-
-file content`, "\n")
-		want := strings.Trim(`
-file content`, "\n")
+		give := "// Copyright © 2021 Ory Corp\n// SPDX-License-Identifier: Apache-2.0\n\nfile content"
+		want := "file content"
 		createTestFile(t, "testfile.go", give)
 		defer os.Remove("testfile.go")
 		have, err := comments.FileContentWithoutHeader("testfile.go", "Copyright ©")
@@ -27,17 +21,8 @@ file content`, "\n")
 	})
 
 	t.Run("known file, other comment first", func(t *testing.T) {
-		give := strings.Trim(`
-// another comment block
-
-// Copyright © 2021 Ory Corp
-// SPDX-License-Identifier: Apache-2.0
-
-file content`, "\n")
-		want := strings.Trim(`
-// another comment block
-
-file content`, "\n")
+		give := "// another comment block\n\n// Copyright © 2021 Ory Corp\n// SPDX-License-Identifier: Apache-2.0\n\nfile content"
+		want := "// another comment block\n\nfile content"
 		createTestFile(t, "testfile.go", give)
 		defer os.Remove("testfile.go")
 		have, err := comments.FileContentWithoutHeader("testfile.go", "Copyright ©")
@@ -46,11 +31,7 @@ file content`, "\n")
 	})
 
 	t.Run("unknown file", func(t *testing.T) {
-		give := strings.Trim(`
-// Copyright © 2021 Ory Corp
-// SPDX-License-Identifier: Apache-2.0
-
-file content`, "\n")
+		give := "// Copyright © 2021 Ory Corp\n// SPDX-License-Identifier: Apache-2.0\n\nfile content"
 		want := give
 		createTestFile(t, "testfile.txt", give)
 		defer os.Remove("testfile.txt")

--- a/cmd/dev/headers/comments/formats_test.go
+++ b/cmd/dev/headers/comments/formats_test.go
@@ -26,19 +26,8 @@ func TestDoubleSlashCommentsRender(t *testing.T) {
 
 func TestDoubleSlashCommentsRemove(t *testing.T) {
 	t.Parallel()
-	give := strings.Trim(`
-// Copyright © 1997 Ory Corp Inc.
-// SPDX-License-Identifier: Apache-2.0
-
-// another comment
-
-name: test
-hello: world`, "\n")
-	want := strings.Trim(`
-// another comment
-
-name: test
-hello: world`, "\n")
+	give := "// Copyright © 1997 Ory Corp Inc.\n// SPDX-License-Identifier: Apache-2.0\n\n// another comment\n\nname: test\nhello: world"
+	want := "// another comment\n\nname: test\nhello: world"
 	have := doubleSlashComments.remove(give, "Copyright ©")
 	assert.Equal(t, want, have)
 }


### PR DESCRIPTION
This makes tests immune to having their test data removed by the license header tool.
