### PR TITLE
chore: correctly handle license headers in TS files

### DIFF
--- a/cmd/dev/headers/comments/files_test.go
+++ b/cmd/dev/headers/comments/files_test.go
@@ -10,8 +10,18 @@ import (
 )
 
 func TestFileContentWithoutHeader(t *testing.T) {
-	t.Run("known file, copyright header", func(t *testing.T) {
+	t.Run("known file, copyright header, empty line", func(t *testing.T) {
 		give := "// Copyright © 2021 Ory Corp\n// SPDX-License-Identifier: Apache-2.0\n\nfile content"
+		want := "file content"
+		createTestFile(t, "testfile.go", give)
+		defer os.Remove("testfile.go")
+		have, err := comments.FileContentWithoutHeader("testfile.go", "Copyright ©")
+		assert.NoError(t, err)
+		assert.Equal(t, want, have)
+	})
+
+	t.Run("known file, copyright header, no empty line", func(t *testing.T) {
+		give := "// Copyright © 2021 Ory Corp\n// SPDX-License-Identifier: Apache-2.0\nfile content"
 		want := "file content"
 		createTestFile(t, "testfile.go", give)
 		defer os.Remove("testfile.go")

--- a/cmd/dev/headers/comments/formats.go
+++ b/cmd/dev/headers/comments/formats.go
@@ -27,7 +27,6 @@ func (f Format) remove(text string, token string) string {
 		}
 		if inComment && !strings.HasPrefix(line, f.startToken) {
 			inComment = false
-			continue
 		}
 		if !inComment {
 			result = append(result, line)


### PR DESCRIPTION
Prettifier removes the empty line between comments in TS and code. This caused the license header feature to eat some code.