### PR TITLE
feat: update config though STDIN

### DIFF
--- a/cmd/cloudx/client/handler.go
+++ b/cmd/cloudx/client/handler.go
@@ -135,7 +135,7 @@ func NewCommandHelper(cmd *cobra.Command) (*CommandHelper, error) {
 	}
 
 	pwReader := func() ([]byte, error) {
-		return term.ReadPassword(int(syscall.Stdin))
+		return term.ReadPassword(syscall.Stdin)
 	}
 	if p, ok := cmd.Context().Value(PasswordReader{}).(passwordReader); ok {
 		pwReader = p


### PR DESCRIPTION
When no `--file` flag is defined, the CLI will now read JSON from STDIN for project config updates.