### PR TITLE
fix(docs): fix env precedence in documentation for ORY_PROJECT_SLUG

### DIFF
--- a/cmd/cloudx/proxy/cmd_proxy.go
+++ b/cmd/cloudx/proxy/cmd_proxy.go
@@ -289,6 +289,6 @@ func printDeprecations(cmd *cobra.Command, target string) {
 		}
 		sort.Strings(values)
 
-		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Attention! We found multiple sources for the project slug. Please clean up environment variables and flags to ensure that the correct value is being used. Found values:\n\n\t%s\n\nOrder of precedence is: %s > %s > %s > --%s\nDecided to use value: %s\n\n", strings.Join(values, "\n\t"), envVarSlug, envVarSDK, envVarKratos, ProjectFlag, target)
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Attention! We found multiple sources for the project slug. Please clean up environment variables and flags to ensure that the correct value is being used. Found values:\n\n\t%s\n\nOrder of precedence is: %s > %s > %s > --%s\nDecided to use value: %s\n\n", strings.Join(values, "\n\t"), envVarSDK, envVarKratos, envVarSlug, ProjectFlag, target)
 	}
 }

--- a/cmd/cloudx/proxy/cmd_proxy_test.go
+++ b/cmd/cloudx/proxy/cmd_proxy_test.go
@@ -42,7 +42,7 @@ func TestGetEndpointURL(t *testing.T) {
 		actual, err := getEndpointURL(cmd)
 		require.NoError(t, err)
 		assert.Equal(t, "https://"+expected+".projects.oryapis.com/", actual.String())
-		assert.Equal(t, "Attention! We found multiple sources for the project slug. Please clean up environment variables and flags to ensure that the correct value is being used. Found values:\n\n\t--project=not-someslug\n\tORY_PROJECT_SLUG=someslug\n\nOrder of precedence is: ORY_PROJECT_SLUG > ORY_SDK_URL > ORY_KRATOS_URL > --project\nDecided to use value: https://someslug.projects.oryapis.com/\n\n", b.String())
+		assert.Equal(t, "Attention! We found multiple sources for the project slug. Please clean up environment variables and flags to ensure that the correct value is being used. Found values:\n\n\t--project=not-someslug\n\tORY_PROJECT_SLUG=someslug\n\nOrder of precedence is: ORY_SDK_URL > ORY_KRATOS_URL > ORY_PROJECT_SLUG > --project\nDecided to use value: https://someslug.projects.oryapis.com/\n\n", b.String())
 	})
 
 	t.Run("should return the right value from the OS using a legacy value", func(t *testing.T) {


### PR DESCRIPTION
Change the document of the precedence of environment variables, the documentation is not matching the implementation.

## Related Issue or Design Document
None

2. You can reproduce the bug by setting two vars in your .env and launching the tunnel.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added the necessary documentation within the code base (if
      appropriate).

## Further comments

**Image of the implementation vs doc**:
<img width="810" alt="Screenshot 2022-12-23 at 22 52 51" src="https://user-images.githubusercontent.com/38230596/209410257-323919a9-d863-4201-bf33-64288d447a9f.png">
