### PR TITLE
chore: persistent dependency installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ docs/cli: .bin/clidoc
 .bin/cli: go.mod go.sum Makefile
 	go build -o .bin/cli -tags sqlite github.com/ory/cli
 
-.bin/golangci-lint-$(GOLANGCI_LINT_VERSION)
+.bin/golangci-lint-$(GOLANGCI_LINT_VERSION):
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b .bin v$(GOLANGCI_LINT_VERSION)
 	mv .bin/golangci-lint .bin/golangci-lint-$(GOLANGCI_LINT_VERSION)
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ export GO111MODULE := on
 export PATH := .bin:${PATH}
 export PWD := $(shell pwd)
 
+GOLANGCI_LINT_VERSION = 1.48.0
+
 GO_DEPENDENCIES = github.com/ory/go-acc \
 				  github.com/golang/mock/mockgen \
 				  github.com/go-swagger/go-swagger/cmd/swagger \
@@ -32,15 +34,16 @@ docs/cli: .bin/clidoc
 .bin/cli: go.mod go.sum Makefile
 	go build -o .bin/cli -tags sqlite github.com/ory/cli
 
-.bin/golangci-lint: Makefile
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b .bin v1.48.0
+.bin/golangci-lint-$(GOLANGCI_LINT_VERSION)
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b .bin v$(GOLANGCI_LINT_VERSION)
+	mv .bin/golangci-lint .bin/golangci-lint-$(GOLANGCI_LINT_VERSION)
 
 .bin/licenses: Makefile
 	curl https://raw.githubusercontent.com/ory/ci/master/licenses/install | sh
 
 .PHONY: lint
-lint: .bin/golangci-lint
-	.bin/golangci-lint run --timeout=10m ./...
+lint: .bin/golangci-lint-$(GOLANGCI_LINT_VERSION)
+	.bin/golangci-lint-$(GOLANGCI_LINT_VERSION) run --timeout=10m ./...
 
 .PHONY: install
 install:


### PR DESCRIPTION
A problem with the way the Makefile currenly installs external dependencies is that each time any change happens in the Makefile, it re-installs all dependencies. This gets annoying in repos that see a lot of changes to their Makefiles. This PR installs dependencies only when really needed, i.e. when they aren't installed or when their required version changes.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added the necessary documentation within the code base (if
      appropriate).

