### PR TITLE
fix: dont update existing headers with new year

### DIFF
--- a/cmd/dev/headers/comments/files.go
+++ b/cmd/dev/headers/comments/files.go
@@ -20,7 +20,8 @@ func FileContentWithoutHeader(path, token string) (string, error) {
 	if !knowsFormat {
 		return text, nil
 	}
-	return format.remove(text, token), nil
+	_, content := format.SplitHeaderFromContent(text, token)
+	return content, nil
 }
 
 func FileContent(path string) (string, error) {

--- a/cmd/dev/headers/comments/files.go
+++ b/cmd/dev/headers/comments/files.go
@@ -6,12 +6,13 @@ package comments
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 )
 
 // FileContentWithoutHeader provides the content of the file with the given path,
 // without the comment block identified by the given token.
-func FileContentWithoutHeader(path, token string) (string, error) {
+func FileContentWithoutHeader(path string, headerRegexp *regexp.Regexp) (string, error) {
 	text, err := FileContent(path)
 	if err != nil {
 		return "", err
@@ -20,7 +21,7 @@ func FileContentWithoutHeader(path, token string) (string, error) {
 	if !knowsFormat {
 		return text, nil
 	}
-	_, content := format.SplitHeaderFromContent(text, token)
+	_, content := format.SplitHeaderFromContent(text, headerRegexp)
 	return content, nil
 }
 

--- a/cmd/dev/headers/comments/files.go
+++ b/cmd/dev/headers/comments/files.go
@@ -12,16 +12,24 @@ import (
 // FileContentWithoutHeader provides the content of the file with the given path,
 // without the comment block identified by the given token.
 func FileContentWithoutHeader(path, token string) (string, error) {
-	buffer, err := os.ReadFile(path)
+	text, err := FileContent(path)
 	if err != nil {
-		return "", fmt.Errorf("cannot open file %q: %w", path, err)
+		return "", err
 	}
-	text := string(buffer)
 	format, knowsFormat := commentFormats[GetFileType(path)]
 	if !knowsFormat {
 		return text, nil
 	}
 	return format.remove(text, token), nil
+}
+
+func FileContent(path string) (string, error) {
+	buffer, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("cannot open file %q: %w", path, err)
+	}
+	text := string(buffer)
+	return text, nil
 }
 
 func StripPrefixes(fileContent string, prefixes []string) (string, string) {

--- a/cmd/dev/headers/comments/files_test.go
+++ b/cmd/dev/headers/comments/files_test.go
@@ -5,6 +5,7 @@ package comments_test
 
 import (
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,7 +19,7 @@ func TestFileContentWithoutHeader(t *testing.T) {
 		want := "file content"
 		createTestFile(t, "testfile.go", give)
 		defer os.Remove("testfile.go")
-		have, err := comments.FileContentWithoutHeader("testfile.go", "Copyright ©")
+		have, err := comments.FileContentWithoutHeader("testfile.go", regexp.MustCompile(`Copyright © \d{4} Ory Corp`))
 		assert.NoError(t, err)
 		assert.Equal(t, want, have)
 	})
@@ -28,7 +29,7 @@ func TestFileContentWithoutHeader(t *testing.T) {
 		want := "file content"
 		createTestFile(t, "testfile.go", give)
 		defer os.Remove("testfile.go")
-		have, err := comments.FileContentWithoutHeader("testfile.go", "Copyright ©")
+		have, err := comments.FileContentWithoutHeader("testfile.go", regexp.MustCompile(`Copyright © \d{4} Ory Corp`))
 		assert.NoError(t, err)
 		assert.Equal(t, want, have)
 	})
@@ -38,7 +39,7 @@ func TestFileContentWithoutHeader(t *testing.T) {
 		want := "// another comment block\n\nfile content"
 		createTestFile(t, "testfile.go", give)
 		defer os.Remove("testfile.go")
-		have, err := comments.FileContentWithoutHeader("testfile.go", "Copyright ©")
+		have, err := comments.FileContentWithoutHeader("testfile.go", regexp.MustCompile(`Copyright © \d{4} Ory Corp`))
 		assert.NoError(t, err)
 		assert.Equal(t, want, have)
 	})
@@ -48,7 +49,7 @@ func TestFileContentWithoutHeader(t *testing.T) {
 		want := give
 		createTestFile(t, "testfile.txt", give)
 		defer os.Remove("testfile.txt")
-		have, err := comments.FileContentWithoutHeader("testfile.txt", "Copyright ©")
+		have, err := comments.FileContentWithoutHeader("testfile.txt", regexp.MustCompile(`Copyright © \d{4} Ory Corp`))
 		assert.NoError(t, err)
 		assert.Equal(t, want, have)
 	})

--- a/cmd/dev/headers/comments/formats.go
+++ b/cmd/dev/headers/comments/formats.go
@@ -3,7 +3,10 @@
 
 package comments
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
 
 // a comment format known to this app
 type Format struct {
@@ -13,13 +16,12 @@ type Format struct {
 	endToken string
 }
 
-func (f Format) SplitHeaderFromContent(text string, token string) (header, content string) {
-	commentWithToken := f.renderLineStart(token)
+func (f Format) SplitHeaderFromContent(text string, headerRegexp *regexp.Regexp) (header, content string) {
 	inComment := false
 	content_lines := []string{}
 	header_lines := []string{}
 	for _, line := range strings.Split(text, "\n") {
-		if strings.HasPrefix(line, commentWithToken) {
+		if f.isComment(line) && headerRegexp.MatchString(line) {
 			inComment = true
 		}
 		if inComment && line == "" {
@@ -28,7 +30,7 @@ func (f Format) SplitHeaderFromContent(text string, token string) (header, conte
 			inComment = false
 			continue
 		}
-		if inComment && !strings.HasPrefix(line, f.startToken) {
+		if inComment && !f.isComment(line) {
 			inComment = false
 		}
 		if !inComment {
@@ -38,6 +40,10 @@ func (f Format) SplitHeaderFromContent(text string, token string) (header, conte
 		}
 	}
 	return strings.Join(header_lines, "\n"), strings.Join(content_lines, "\n")
+}
+
+func (f Format) isComment(line string) bool {
+	return strings.HasPrefix(line, f.startToken)
 }
 
 // renders the given text block (consisting of many text lines) into a comment block

--- a/cmd/dev/headers/comments/formats.go
+++ b/cmd/dev/headers/comments/formats.go
@@ -13,31 +13,6 @@ type Format struct {
 	endToken string
 }
 
-// removes the comment block in the given format containing the given token from the given text
-func (f Format) remove(text string, token string) string {
-	commentWithToken := f.renderLineStart(token)
-	inComment := false
-	result := []string{}
-	for _, line := range strings.Split(text, "\n") {
-		if strings.HasPrefix(line, commentWithToken) {
-			inComment = true
-		}
-		if inComment && line == "" {
-			// the type of comment blocks we remove here is separated by an empty line
-			// --> empty line marks the end of our comment block
-			inComment = false
-			continue
-		}
-		if inComment && !strings.HasPrefix(line, f.startToken) {
-			inComment = false
-		}
-		if !inComment {
-			result = append(result, line)
-		}
-	}
-	return strings.Join(result, "\n")
-}
-
 func (f Format) SplitHeaderFromContent(text string, token string) (header, content string) {
 	commentWithToken := f.renderLineStart(token)
 	inComment := false

--- a/cmd/dev/headers/comments/formats_test.go
+++ b/cmd/dev/headers/comments/formats_test.go
@@ -31,7 +31,7 @@ func TestDoubleSlashCommentsRemove(t *testing.T) {
 	t.Parallel()
 	give := "// Copyright © 1997 Ory Corp Inc.\n// SPDX-License-Identifier: Apache-2.0\n\n// another comment\n\nname: test\nhello: world"
 	want := "// another comment\n\nname: test\nhello: world"
-	have := doubleSlashComments.remove(give, "Copyright ©")
+	_, have := doubleSlashComments.SplitHeaderFromContent(give, "Copyright ©")
 	assert.Equal(t, want, have)
 }
 
@@ -65,7 +65,7 @@ hello: world`, "\n")
 
 name: test
 hello: world`, "\n")
-	have := poundComments.remove(give, "Copyright ©")
+	_, have := poundComments.SplitHeaderFromContent(give, "Copyright ©")
 	assert.Equal(t, want, have)
 }
 
@@ -114,6 +114,6 @@ hello: world`, "\n")
 
 name: test
 hello: world`, "\n")
-	have := htmlComments.remove(give, "Copyright ©")
+	_, have := htmlComments.SplitHeaderFromContent(give, "Copyright ©")
 	assert.Equal(t, want, have)
 }

--- a/cmd/dev/headers/comments/formats_test.go
+++ b/cmd/dev/headers/comments/formats_test.go
@@ -5,6 +5,7 @@ package comments
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -31,7 +32,7 @@ func TestDoubleSlashCommentsRemove(t *testing.T) {
 	t.Parallel()
 	give := "// Copyright © 1997 Ory Corp Inc.\n// SPDX-License-Identifier: Apache-2.0\n\n// another comment\n\nname: test\nhello: world"
 	want := "// another comment\n\nname: test\nhello: world"
-	_, have := doubleSlashComments.SplitHeaderFromContent(give, "Copyright ©")
+	_, have := doubleSlashComments.SplitHeaderFromContent(give, regexp.MustCompile(`Copyright © \d{4} Ory Corp Inc.`))
 	assert.Equal(t, want, have)
 }
 
@@ -65,7 +66,7 @@ hello: world`, "\n")
 
 name: test
 hello: world`, "\n")
-	_, have := poundComments.SplitHeaderFromContent(give, "Copyright ©")
+	_, have := poundComments.SplitHeaderFromContent(give, regexp.MustCompile(`Copyright © \d{4} Ory Corp Inc.`))
 	assert.Equal(t, want, have)
 }
 
@@ -114,6 +115,6 @@ hello: world`, "\n")
 
 name: test
 hello: world`, "\n")
-	_, have := htmlComments.SplitHeaderFromContent(give, "Copyright ©")
+	_, have := htmlComments.SplitHeaderFromContent(give, regexp.MustCompile(`Copyright © \d{4} Ory Corp Inc.`))
 	assert.Equal(t, want, have)
 }

--- a/cmd/dev/headers/copyright.go
+++ b/cmd/dev/headers/copyright.go
@@ -22,13 +22,15 @@ import (
 // HEADER_TOKEN defines a text snippet to recognize an existing copyright header in a file.
 const HEADER_TOKEN = "Copyright ©"
 
-const HEADER_REGEXP = HEADER_TOKEN + `\s+(\d{4})\s+`
+const COMPANY_NAME = "Ory Corp"
+
+const HEADER_REGEXP = HEADER_TOKEN + `\s+(\d{4})\s+` + COMPANY_NAME
 
 // HEADER_TEMPLATE_OPEN_SOURCE defines the full header text for open-source files.
-const HEADER_TEMPLATE_OPEN_SOURCE = HEADER_TOKEN + " %d Ory Corp\nSPDX-License-Identifier: Apache-2.0"
+const HEADER_TEMPLATE_OPEN_SOURCE = HEADER_TOKEN + " %d " + COMPANY_NAME + "\nSPDX-License-Identifier: Apache-2.0"
 
 // HEADER_TEMPLATE_PROPRIETARY defines the full header text for proprietary files.
-const HEADER_TEMPLATE_PROPRIETARY = HEADER_TOKEN + " %d Ory Corp\nProprietary and confidential.\nUnauthorized copying of this file is prohibited."
+const HEADER_TEMPLATE_PROPRIETARY = HEADER_TOKEN + " %d " + COMPANY_NAME + "\nProprietary and confidential.\nUnauthorized copying of this file is prohibited."
 
 // file types that we don't want to add copyright headers to
 var noHeadersFor = []comments.FileType{"md", "yml", "yaml"}
@@ -37,8 +39,8 @@ var noHeadersFor = []comments.FileType{"md", "yml", "yaml"}
 var defaultExcludedFolders = []string{"dist", "node_modules", "vendor"}
 
 // AddHeaders adds or updates the Ory copyright header in all applicable files within the given directory.
-// Skips the file if any existing headers match `skipMatchingHeaders`
-func AddHeaders(dir string, headerText string, exclude []string, skipMatchingHeaders *regexp.Regexp) error {
+// Skips the file if any existing headers match `headerRegexp`
+func AddHeaders(dir string, headerText string, exclude []string, headerRegexp *regexp.Regexp) error {
 	gitIgnore, _ := ignore.CompileIgnoreFile(filepath.Join(dir, ".gitignore"))
 	prettierIgnore, _ := ignore.CompileIgnoreFile(filepath.Join(dir, ".prettierignore"))
 	return filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
@@ -78,8 +80,8 @@ func AddHeaders(dir string, headerText string, exclude []string, skipMatchingHea
 		if err != nil {
 			return err
 		}
-		header, contentNoHeader := format.SplitHeaderFromContent(content, HEADER_TOKEN)
-		if skipMatchingHeaders != nil && skipMatchingHeaders.MatchString(header) {
+		header, contentNoHeader := format.SplitHeaderFromContent(content, headerRegexp)
+		if len(header) > 0 {
 			return nil
 		}
 

--- a/cmd/dev/headers/copyright_test.go
+++ b/cmd/dev/headers/copyright_test.go
@@ -5,6 +5,7 @@ package headers
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -41,7 +42,7 @@ func TestAddHeaders(t *testing.T) {
 				dir := root.CreateDir(test.ext)
 				filename := fmt.Sprintf("file.%s", test.ext)
 				dir.CreateFile(filename, test.give)
-				err := AddHeaders(dir.Path, 2022, HEADER_TEMPLATE_OPEN_SOURCE, []string{})
+				err := AddHeaders(dir.Path, fmt.Sprintf(HEADER_TEMPLATE_OPEN_SOURCE, 2022), []string{}, regexp.MustCompile(HEADER_REGEXP))
 				assert.NoError(t, err)
 				assert.Equal(t, test.want, dir.Content(filename))
 			})
@@ -53,7 +54,7 @@ func TestAddHeaders(t *testing.T) {
 		dir.CreateFile(".prettierignore", "prettier-ignored.go")
 		content := "package ignore_this_file"
 		dir.CreateFile("prettier-ignored.go", content)
-		err := AddHeaders(dir.Path, 2022, HEADER_TEMPLATE_OPEN_SOURCE, []string{})
+		err := AddHeaders(dir.Path, fmt.Sprintf(HEADER_TEMPLATE_OPEN_SOURCE, 2022), []string{}, regexp.MustCompile(HEADER_REGEXP))
 		assert.NoError(t, err)
 		assert.Equal(t, content, dir.Content("prettier-ignored.go"))
 	})
@@ -64,7 +65,7 @@ func TestAddHeaders(t *testing.T) {
 		dir.CreateFile(".prettierignore", "subdir/")
 		content := "package ignore_this_file"
 		subdir.CreateFile("prettier-ignored.go", content)
-		err := AddHeaders(dir.Path, 2022, HEADER_TEMPLATE_OPEN_SOURCE, []string{})
+		err := AddHeaders(dir.Path, fmt.Sprintf(HEADER_TEMPLATE_OPEN_SOURCE, 2022), []string{}, regexp.MustCompile(HEADER_REGEXP))
 		assert.NoError(t, err)
 		assert.Equal(t, content, subdir.Content("prettier-ignored.go"))
 	})
@@ -75,7 +76,7 @@ func TestAddHeaders(t *testing.T) {
 		dir.CreateFile(".gitignore", "subdir/")
 		content := "package ignore_this_file"
 		subdir.CreateFile("git-ignored.go", content)
-		err := AddHeaders(dir.Path, 2022, HEADER_TEMPLATE_OPEN_SOURCE, []string{})
+		err := AddHeaders(dir.Path, fmt.Sprintf(HEADER_TEMPLATE_OPEN_SOURCE, 2022), []string{}, regexp.MustCompile(HEADER_REGEXP))
 		assert.NoError(t, err)
 		assert.Equal(t, content, subdir.Content("git-ignored.go"))
 	})
@@ -84,7 +85,7 @@ func TestAddHeaders(t *testing.T) {
 		dir := root.CreateDir("gitignored")
 		dir.CreateFile(".gitignore", "git-ignored.go")
 		dir.CreateFile("git-ignored.go", "package ignore_this_file")
-		err := AddHeaders(dir.Path, 2022, HEADER_TEMPLATE_OPEN_SOURCE, []string{})
+		err := AddHeaders(dir.Path, fmt.Sprintf(HEADER_TEMPLATE_OPEN_SOURCE, 2022), []string{}, regexp.MustCompile(HEADER_REGEXP))
 		assert.NoError(t, err)
 		assert.Equal(t, "package ignore_this_file", dir.Content("git-ignored.go"))
 	})
@@ -93,7 +94,7 @@ func TestAddHeaders(t *testing.T) {
 		dir := root.CreateDir("node_modules").CreateDir(".bin")
 		content := "#!/usr/bin/env bash\necho hello"
 		dir.CreateFile("nodemon.ts", content)
-		err := AddHeaders(dir.Path, 2022, HEADER_TEMPLATE_OPEN_SOURCE, []string{})
+		err := AddHeaders(dir.Path, fmt.Sprintf(HEADER_TEMPLATE_OPEN_SOURCE, 2022), []string{}, regexp.MustCompile(HEADER_REGEXP))
 		assert.NoError(t, err)
 		assert.Equal(t, content, dir.Content("nodemon.ts"))
 	})
@@ -103,15 +104,48 @@ func TestAddHeaders(t *testing.T) {
 		dir2 := dir1.CreateDir("generated")
 		content := "package this_file_is_excluded"
 		dir2.CreateFile("excluded.go", content)
-		err := AddHeaders(dir1.Path, 2022, HEADER_TEMPLATE_OPEN_SOURCE, []string{"generated"})
+		err := AddHeaders(dir1.Path, fmt.Sprintf(HEADER_TEMPLATE_OPEN_SOURCE, 2022), []string{"generated"}, regexp.MustCompile(HEADER_REGEXP))
 		assert.NoError(t, err)
 		assert.Equal(t, content, dir2.Content("excluded.go"))
+	})
+
+	t.Run("does not change copyright year for existing header", func(t *testing.T) {
+		type test struct {
+			ext  string
+			want string
+		}
+		tests := []test{
+			{ext: "cs", want: "// Copyright © 2022 Ory Corp\n// SPDX-License-Identifier: Apache-2.0\n\nusing System;\n\nnamespace Foo.Bar {\n"},
+			{ext: "dart", want: "// Copyright © 2022 Ory Corp\n// SPDX-License-Identifier: Apache-2.0\n\nint a = 1;\nint b = 2;"},
+			{ext: "go", want: "// Copyright © 2022 Ory Corp\n// SPDX-License-Identifier: Apache-2.0\n\npackage test\n\nimport foo\n"},
+			{ext: "java", want: "// Copyright © 2022 Ory Corp\n// SPDX-License-Identifier: Apache-2.0\n\nimport java.io.File;\n\nFile myFile = new File();"},
+			{ext: "js", want: "// Copyright © 2022 Ory Corp\n// SPDX-License-Identifier: Apache-2.0\n\nconst a = 1\nconst b = 2\n"},
+			{ext: "md", want: "# hello world"},
+			{ext: "php", want: "// Copyright © 2022 Ory Corp\n// SPDX-License-Identifier: Apache-2.0\n\n$a = 1;\n$b = 2;\n"},
+			{ext: "py", want: "# Copyright © 2022 Ory Corp\n# SPDX-License-Identifier: Apache-2.0\n\na = 1\nb = 2\n"},
+			{ext: "rb", want: "# Copyright © 2022 Ory Corp\n# SPDX-License-Identifier: Apache-2.0\n\na = 1\nb = 2\n"},
+			{ext: "rs", want: "// Copyright © 2022 Ory Corp\n// SPDX-License-Identifier: Apache-2.0\n\nlet a = 1;\nlet mut b = 2;\n"},
+			{ext: "ts", want: "// Copyright © 2022 Ory Corp\n// SPDX-License-Identifier: Apache-2.0\n\nconst a = 1\nconst b = 2\n"},
+			{ext: "vue", want: "<!-- Copyright © 2022 Ory Corp -->\n<!-- SPDX-License-Identifier: Apache-2.0 -->\n\n<template>\n<Header />"},
+			{ext: "yml", want: "one: two\nalpha: beta"},
+			{ext: "yaml", want: "one: two\nalpha: beta"},
+		}
+		for _, test := range tests {
+			t.Run(fmt.Sprintf("%q file type", test.ext), func(t *testing.T) {
+				dir := root.CreateDir(fmt.Sprintf("no-update-%s", test.ext))
+				filename := fmt.Sprintf("file.%s", test.ext)
+				dir.CreateFile(filename, test.want)
+				err := AddHeaders(dir.Path, fmt.Sprintf(HEADER_TEMPLATE_OPEN_SOURCE, 2023), []string{}, regexp.MustCompile(HEADER_REGEXP))
+				assert.NoError(t, err)
+				assert.Equal(t, test.want, dir.Content(filename))
+			})
+		}
 	})
 
 	t.Run("open-source copyright headers", func(t *testing.T) {
 		dir := root.CreateDir("open-source")
 		dir.CreateFile("file.go", "package open_source")
-		err := AddHeaders(dir.Path, 2022, HEADER_TEMPLATE_OPEN_SOURCE, []string{})
+		err := AddHeaders(dir.Path, fmt.Sprintf(HEADER_TEMPLATE_OPEN_SOURCE, 2022), []string{}, regexp.MustCompile(HEADER_REGEXP))
 		assert.NoError(t, err)
 		assert.Equal(t, "// Copyright © 2022 Ory Corp\n// SPDX-License-Identifier: Apache-2.0\n\npackage open_source", dir.Content("file.go"))
 	})
@@ -119,7 +153,7 @@ func TestAddHeaders(t *testing.T) {
 	t.Run("proprietary copyright headers", func(t *testing.T) {
 		dir := root.CreateDir("open-source")
 		dir.CreateFile("file.go", "package open_source")
-		err := AddHeaders(dir.Path, 2022, HEADER_TEMPLATE_PROPRIETARY, []string{})
+		err := AddHeaders(dir.Path, fmt.Sprintf(HEADER_TEMPLATE_PROPRIETARY, 2022), []string{}, regexp.MustCompile(HEADER_REGEXP))
 		assert.NoError(t, err)
 		assert.Equal(t, "// Copyright © 2022 Ory Corp\n// Proprietary and confidential.\n// Unauthorized copying of this file is prohibited.\n\npackage open_source", dir.Content("file.go"))
 	})
@@ -141,7 +175,7 @@ func TestAddHeaders(t *testing.T) {
 
 				content := "package open_source"
 				dir.CreateFile("file.go", fmt.Sprintf("%s%s", test.bom, content))
-				err := AddHeaders(dir.Path, 2022, HEADER_TEMPLATE_PROPRIETARY, []string{})
+				err := AddHeaders(dir.Path, fmt.Sprintf(HEADER_TEMPLATE_PROPRIETARY, 2022), []string{}, regexp.MustCompile(HEADER_REGEXP))
 				assert.NoError(t, err)
 				assert.Equal(t, fmt.Sprintf("%s// Copyright © 2022 Ory Corp\n// Proprietary and confidential.\n// Unauthorized copying of this file is prohibited.\n\n%s", test.bom, content), dir.Content("file.go"))
 			})


### PR DESCRIPTION
Deactivates updating an already existing copyright header with a different year.
The year should denote the year of original publication.

## Related Issue or Design Document

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added the necessary documentation within the code base (if
      appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
