### PR TITLE
feat: project flag accepts slug

### DIFF
--- a/cmd/cloudx/client/client.go
+++ b/cmd/cloudx/client/client.go
@@ -27,7 +27,7 @@ import (
 const projectFlag = "project"
 
 func RegisterProjectFlag(f *flag.FlagSet) {
-	f.String(projectFlag, "", "The project to use")
+	f.String(projectFlag, "", "The project to use, either project ID or a (partial) slug.")
 }
 
 func Client(cmd *cobra.Command) (*retryablehttp.Client, *AuthContext, *cloud.Project, error) {

--- a/cmd/cloudx/client/handler.go
+++ b/cmd/cloudx/client/handler.go
@@ -534,14 +534,14 @@ func (h *CommandHelper) GetProject(projectOrSlug string) (*cloud.Project, error)
 
 		var availableSlugs string
 		for _, pm := range pjs {
-			if pm.GetSlug() == projectOrSlug {
+			if len(projectOrSlug) >= 3 && strings.HasPrefix(pm.GetSlug(), projectOrSlug) {
 				id = uuid.FromStringOrNil(pm.GetId())
 			} else {
 				availableSlugs = availableSlugs + "\n" + pm.GetSlug()
 			}
 		}
 		if id == uuid.Nil {
-			return nil, errors.Errorf("no project found with slug %s, only slugs known are: %s", projectOrSlug, availableSlugs)
+			return nil, errors.Errorf("no project found with slug %s, only slugs known are: %v", projectOrSlug, availableSlugs)
 		}
 	}
 

--- a/cmd/cloudx/client/handler.go
+++ b/cmd/cloudx/client/handler.go
@@ -20,16 +20,17 @@ import (
 
 	"github.com/gofrs/uuid/v3"
 	"github.com/imdario/mergo"
-	cloud "github.com/ory/client-go"
-	"github.com/ory/x/cmdx"
-	"github.com/ory/x/flagx"
-	"github.com/ory/x/jsonx"
-	"github.com/ory/x/stringsx"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/tidwall/gjson"
 	"golang.org/x/term"
+
+	cloud "github.com/ory/client-go"
+	"github.com/ory/x/cmdx"
+	"github.com/ory/x/flagx"
+	"github.com/ory/x/jsonx"
+	"github.com/ory/x/stringsx"
 )
 
 const (

--- a/cmd/cloudx/client/handler.go
+++ b/cmd/cloudx/client/handler.go
@@ -512,7 +512,7 @@ func (h *CommandHelper) ListProjects() ([]cloud.ProjectMetadata, error) {
 
 func (h *CommandHelper) GetProject(projectOrSlug string) (*cloud.Project, error) {
 	if projectOrSlug == "" {
-		return nil, errors.Errorf("No project selected! Please use the flag --project to specify one.\n")
+		return nil, errors.Errorf("No project selected! Please see the help message on how to set one.")
 	}
 
 	ac, err := h.EnsureContext()

--- a/cmd/cloudx/client/handler.go
+++ b/cmd/cloudx/client/handler.go
@@ -524,13 +524,13 @@ func (h *CommandHelper) GetProject(projectOrSlug string) (*cloud.Project, error)
 	id := uuid.FromStringOrNil(projectOrSlug)
 	if id == uuid.Nil {
 		pjs, err := h.ListProjects()
+		if err != nil {
+			return nil, err
+		}
 		for _, pm := range pjs {
 			if pm.GetSlug() == projectOrSlug {
 				id = uuid.FromStringOrNil(pm.GetId())
 			}
-		}
-		if err != nil {
-			return nil, err
 		}
 	}
 	if id == uuid.Nil {

--- a/cmd/cloudx/client/handler.go
+++ b/cmd/cloudx/client/handler.go
@@ -511,6 +511,10 @@ func (h *CommandHelper) ListProjects() ([]cloud.ProjectMetadata, error) {
 }
 
 func (h *CommandHelper) GetProject(projectOrSlug string) (*cloud.Project, error) {
+	if projectOrSlug == "" {
+		return nil, errors.Errorf("No project selected! Please use the flag --project to specify one.\n")
+	}
+
 	ac, err := h.EnsureContext()
 	if err != nil {
 		return nil, err
@@ -527,14 +531,18 @@ func (h *CommandHelper) GetProject(projectOrSlug string) (*cloud.Project, error)
 		if err != nil {
 			return nil, err
 		}
+
+		var availableSlugs string
 		for _, pm := range pjs {
 			if pm.GetSlug() == projectOrSlug {
 				id = uuid.FromStringOrNil(pm.GetId())
+			} else {
+				availableSlugs = availableSlugs + "\n" + pm.GetSlug()
 			}
 		}
-	}
-	if id == uuid.Nil {
-		return nil, errors.Errorf("No project selected! Please use the flag --project to specify one.\n")
+		if id == uuid.Nil {
+			return nil, errors.Errorf("no project found with slug %s, only slugs known are: %s", projectOrSlug, availableSlugs)
+		}
 	}
 
 	project, res, err := c.ProjectApi.GetProject(h.Ctx, id.String()).Execute()

--- a/cmd/cloudx/client/handler.go
+++ b/cmd/cloudx/client/handler.go
@@ -532,12 +532,14 @@ func (h *CommandHelper) GetProject(projectOrSlug string) (*cloud.Project, error)
 			return nil, err
 		}
 
-		var availableSlugs string
-		for _, pm := range pjs {
-			if len(projectOrSlug) >= 3 && strings.HasPrefix(pm.GetSlug(), projectOrSlug) {
+		availableSlugs := make([]string, len(pjs))
+		for i, pm := range pjs {
+			availableSlugs[i] = pm.GetSlug()
+			if strings.HasPrefix(pm.GetSlug(), projectOrSlug) {
+				if id != uuid.Nil {
+					return nil, errors.Errorf("The slug prefix %q is not unique, please use more characters. Found slugs:\n%s", projectOrSlug, strings.Join(availableSlugs, "\n"))
+				}
 				id = uuid.FromStringOrNil(pm.GetId())
-			} else {
-				availableSlugs = availableSlugs + "\n" + pm.GetSlug()
 			}
 		}
 		if id == uuid.Nil {

--- a/cmd/cloudx/client/handler_test.go
+++ b/cmd/cloudx/client/handler_test.go
@@ -76,7 +76,7 @@ func TestCommandHelper(t *testing.T) {
 			require.NoError(t, err)
 			assertValidProject(t, p)
 
-			actual, err := loggedIn.GetProject(p.Slug)
+			actual, err := loggedIn.GetProject(p.Slug[0:4])
 			require.NoError(t, err)
 			assert.Equal(t, p, actual)
 		})

--- a/cmd/cloudx/client/handler_test.go
+++ b/cmd/cloudx/client/handler_test.go
@@ -76,9 +76,9 @@ func TestCommandHelper(t *testing.T) {
 			require.NoError(t, err)
 			assertValidProject(t, p)
 
-			p, err = loggedIn.GetProject(p.Slug)
+			actual, err := loggedIn.GetProject(p.Slug)
 			require.NoError(t, err)
-			assertValidProject(t, p)
+			assert.Equal(t, p, actual)
 		})
 
 		t.Run("is not able to list projects if not authenticated and quiet flag", func(t *testing.T) {

--- a/cmd/cloudx/client/handler_test.go
+++ b/cmd/cloudx/client/handler_test.go
@@ -75,6 +75,10 @@ func TestCommandHelper(t *testing.T) {
 			p, err := loggedIn.GetProject(project)
 			require.NoError(t, err)
 			assertValidProject(t, p)
+
+			p, err = loggedIn.GetProject(p.Slug)
+			require.NoError(t, err)
+			assertValidProject(t, p)
 		})
 
 		t.Run("is not able to list projects if not authenticated and quiet flag", func(t *testing.T) {

--- a/cmd/cloudx/project/update_namespace_config.go
+++ b/cmd/cloudx/project/update_namespace_config.go
@@ -44,12 +44,12 @@ class Example implements Namespace {}
 			patch := fmt.Sprintf(`/services/permission/config/namespaces={"location": "base64://%s"}`,
 				base64.StdEncoding.EncodeToString(data))
 
-			projectID, err := client.ProjectID(cmd, h)
+			project, err := h.GetProject(flagx.MustGetString(cmd, "project"))
 			if err != nil {
 				return err
 			}
 
-			p, err := h.PatchProject(projectID.String(), nil, nil, []string{patch}, nil)
+			p, err := h.PatchProject(project.Id, nil, nil, []string{patch}, nil)
 			if err != nil {
 				return cmdx.PrintOpenAPIError(cmd, err)
 			}

--- a/cmd/cloudx/project/update_namespace_config.go
+++ b/cmd/cloudx/project/update_namespace_config.go
@@ -44,7 +44,7 @@ class Example implements Namespace {}
 			patch := fmt.Sprintf(`/services/permission/config/namespaces={"location": "base64://%s"}`,
 				base64.StdEncoding.EncodeToString(data))
 
-			projectID, err := client.ProjectID(cmd)
+			projectID, err := client.ProjectID(cmd, h)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This PR enables supplying slugs to `cmd subcmd project PROJECTORSLUG` / `cmd ls identities PROJECTORSLUG`.

## Related Issue or Design Document

closes #267 
closes #156

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added the necessary documentation within the code base (if
      appropriate).

## Further comments
