### PR TITLE
fix: add linux-arm64 binary config into npm

### DIFF
--- a/npm/index.js
+++ b/npm/index.js
@@ -13,6 +13,7 @@ module.exports = binwrap({
   binaries: ["ory"],
   urls: {
     "linux-x64": root + "/ory_" + version + "-linux_64bit.tar.gz",
+    "linux-arm64": root + "/ory_" + version + "-linux_arm64.tar.gz",
     "win32-x64": root + "/ory_" + version + "-windows_64bit.zip",
     "darwin-x64": root + "/ory_" + version + "-macOS_64bit.tar.gz",
     "darwin-arm64": root + "/ory_" + version + "-macOS_arm64.tar.gz",


### PR DESCRIPTION
Add configuration to allow the npm package to work on linux-arm64

## Related Issue or Design Document

Installing or trying to use the ory cli via npm fails on arm64 linux, even though a binary is available. This PR fixes it.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added the necessary documentation within the code base (if
      appropriate).
