### PR TITLE
feat: store refreshed tokens

### DIFF
--- a/cmd/cloudx/client/command_helper_test.go
+++ b/cmd/cloudx/client/command_helper_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/playwright-community/playwright-go"
@@ -215,6 +216,9 @@ func TestCommandHelper(t *testing.T) {
 		require.NoError(t, h.Authenticate(ctx))
 		t.Logf("authentication successful")
 
+		// we don't need playwright anymore
+		cleanup()
+
 		// assert success
 		config, err := h.GetAuthenticatedConfig(ctx)
 		require.NoError(t, err)
@@ -238,6 +242,28 @@ func TestCommandHelper(t *testing.T) {
 
 		assert.JSONEq(t, "[]", testhelpers.ListRelationTuples(ctx, t, defaultProject.Id).Get("relation_tuples").Raw)
 		t.Logf("list relation tuples request successful")
+
+		t.Run("refreshes and stores the refreshed oauth2 access token", func(t *testing.T) {
+			ctx := client.ContextWithOptions(ctx, client.WithOpenBrowserHook(func(uri string) error {
+				return fmt.Errorf("open browser hook not expected: %s", uri)
+			}))
+
+			oldToken := *config.AccessToken
+			oldToken.Expiry = time.Unix(0, 0)
+			oldConfig := *config
+			oldConfig.AccessToken = &oldToken
+			require.NoError(t, h.UpdateConfig(&oldConfig))
+
+			actual, err := h.GetProject(ctx, defaultProject.Id, nil)
+			require.NoError(t, err)
+			assert.Equal(t, defaultProject.Id, actual.Id)
+
+			newConfig, err := h.GetAuthenticatedConfig(ctx)
+			require.NoError(t, err)
+			require.NotNil(t, newConfig.AccessToken)
+			assert.NotEmpty(t, newConfig.AccessToken.AccessToken)
+			assert.NotEqual(t, oldToken.AccessToken, newConfig.AccessToken.AccessToken)
+		})
 	})
 
 	t.Run("func=CreateProjectAPIKey and DeleteApiKey", func(t *testing.T) {

--- a/cmd/cloudx/client/config.go
+++ b/cmd/cloudx/client/config.go
@@ -52,27 +52,32 @@ func getConfigPath() (string, error) {
 	), nil
 }
 
-func (h *CommandHelper) UpdateConfig(c *Config) error {
+func (c *Config) writeUpdate() error {
 	c.Version = ConfigVersion
-	h.config = c
 
-	f, err := os.OpenFile(h.configLocation, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+	f, err := os.OpenFile(c.location, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
-		return fmt.Errorf("unable to open file %q for writing: %w", h.configLocation, err)
+		return fmt.Errorf("unable to open file %q for writing: %w", c.location, err)
 	}
 	defer f.Close()
 
 	if err := json.NewEncoder(f).Encode(c); err != nil {
-		return fmt.Errorf("unable to write configuration file %q: %w", h.configLocation, err)
+		return fmt.Errorf("unable to write configuration file %q: %w", c.location, err)
 	}
-
 	return nil
+}
+
+func (h *CommandHelper) UpdateConfig(c *Config) error {
+	h.config = c
+	return c.writeUpdate()
 }
 
 func (h *CommandHelper) getOrCreateConfig() (*Config, error) {
 	c, err := h.getConfig()
 	if errors.Is(err, ErrNoConfig) {
-		return &Config{}, nil
+		return &Config{
+			location: h.configLocation,
+		}, nil
 	}
 	return c, err
 }
@@ -98,7 +103,9 @@ func readConfig(location string) (*Config, error) {
 	}
 	defer f.Close()
 
-	var c Config
+	c := Config{
+		location: location,
+	}
 	if err := json.NewDecoder(f).Decode(&c); err != nil {
 		return nil, fmt.Errorf("unable to JSON decode the ory config file %q: %w", location, err)
 	}
@@ -158,6 +165,8 @@ type Config struct {
 	// isAuthenticated is a flag that we set once the session was checked and is valid.
 	// Because this is not stored to the config file, it means that every command execution does at most one session check.
 	isAuthenticated bool
+	// location is the path to the configuration file
+	location string
 }
 
 func (c *Config) ID() string {
@@ -195,5 +204,29 @@ type Identity struct {
 }
 
 func (c *Config) TokenSource(ctx context.Context) oauth2.TokenSource {
-	return oauth2ClientConfig().TokenSource(ctx, c.AccessToken)
+	return &autoStoreRefreshedTokenSource{
+		ctx: ctx,
+		c:   c,
+	}
+}
+
+// autoStoreRefreshedTokenSource is a token source that automatically stores the refreshed token in the config file.
+// Because it holds the context, it should not be re-used. Always create a new one using Config.TokenSource() with the current context.
+type autoStoreRefreshedTokenSource struct {
+	ctx context.Context
+	c   *Config
+}
+
+func (s *autoStoreRefreshedTokenSource) Token() (*oauth2.Token, error) {
+	newToken, err := oauth2ClientConfig().TokenSource(s.ctx, s.c.AccessToken).Token()
+	if err != nil {
+		return nil, err
+	}
+	if newToken.AccessToken != s.c.AccessToken.AccessToken {
+		s.c.AccessToken = newToken
+		if err := s.c.writeUpdate(); err != nil {
+			return nil, err
+		}
+	}
+	return newToken, nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -17,6 +18,8 @@ import (
 	"github.com/ory/kratos/cmd/jsonnet"
 	"github.com/ory/x/cmdx"
 )
+
+var commandTemplatingOnce sync.Once
 
 func NewRootCmd() *cobra.Command {
 	c := &cobra.Command{
@@ -48,7 +51,9 @@ func NewRootCmd() *cobra.Command {
 		cloudx.NewIsCmd(),
 		versionCmd,
 	)
-	cmdx.EnableUsageTemplating(c)
+	commandTemplatingOnce.Do(func() {
+		cmdx.EnableUsageTemplating(c)
+	})
 
 	return c
 }


### PR DESCRIPTION
With this change, refreshed tokens are now stored in the config.
We might need to handle the case where the refresh token expired more gracefully?