### PR TITLE
test: always use OAuth2 token instead of session token

### DIFF
--- a/cmd/cloudx/accountexperience/accountexperience_test.go
+++ b/cmd/cloudx/accountexperience/accountexperience_test.go
@@ -5,6 +5,8 @@ package accountexperience_test
 
 import (
 	"context"
+	cloud "github.com/ory/client-go"
+	"github.com/ory/x/cmdx"
 	"strings"
 	"testing"
 
@@ -16,22 +18,22 @@ import (
 	"github.com/ory/cli/cmd/cloudx/testhelpers"
 )
 
+var (
+	ctx     context.Context
+	project *cloud.Project
+	cmd     *cmdx.CommandExecuter
+)
+
 func TestMain(m *testing.M) {
+	ctx, _, _, project, cmd = testhelpers.CreateDefaultAssetsBrowser()
 	testhelpers.UseStaging()
 	m.Run()
 }
 
 func TestOpenAXPages(t *testing.T) {
-	_, _, _, sessionToken := testhelpers.RegisterAccount(context.Background(), t)
-	ctx := client.ContextWithOptions(context.Background(),
-		client.WithConfigLocation(testhelpers.NewConfigFile(t)),
-		client.WithSessionToken(t, sessionToken))
-	project := testhelpers.CreateProject(ctx, t, nil)
-	cmd := testhelpers.Cmd(ctx)
-
 	t.Run("is able to open all pages", func(t *testing.T) {
 		for _, flowType := range []string{"login", "registration", "recovery", "verification", "settings"} {
-			testhelpers.Cmd(client.ContextWithOptions(ctx, client.WithOpenBrowserHook(func(uri string) error {
+			cmd := testhelpers.Cmd(client.ContextWithOptions(ctx, client.WithOpenBrowserHook(func(uri string) error {
 				assert.Truef(t, strings.HasPrefix(uri, "https://"+project.Slug), "expected %q to have prefix %q", uri, "https://"+project.Slug)
 				assert.Contains(t, uri, flowType)
 				return nil

--- a/cmd/cloudx/accountexperience/accountexperience_test.go
+++ b/cmd/cloudx/accountexperience/accountexperience_test.go
@@ -5,10 +5,11 @@ package accountexperience_test
 
 import (
 	"context"
-	cloud "github.com/ory/client-go"
-	"github.com/ory/x/cmdx"
 	"strings"
 	"testing"
+
+	cloud "github.com/ory/client-go"
+	"github.com/ory/x/cmdx"
 
 	"github.com/stretchr/testify/assert"
 

--- a/cmd/cloudx/client/auth.go
+++ b/cmd/cloudx/client/auth.go
@@ -173,7 +173,7 @@ func (h *CommandHelper) oAuth2DanceWithServer(ctx context.Context, client *oauth
 		l            net.Listener
 		state        = randx.MustString(32, randx.AlphaNum)
 		pkceVerifier = oauth2.GenerateVerifier()
-		ports        = []int{12345, 34525, 49763, 51238, 59724, 60582, 62125}
+		ports        = []int{12345, 15793, 17628, 19834, 23730, 27462, 34525, 36209, 42827, 46718, 49763, 51238, 52213, 57923, 59724, 60582, 62125, 65321, 49876, 54321, 59876, 60987, 62345, 63456, 64567, 65123, 65234, 65432, 65500, 65510, 65520, 65530}
 	)
 	rand.Shuffle(len(ports), func(i, j int) { ports[i], ports[j] = ports[j], ports[i] })
 	for _, port := range ports {

--- a/cmd/cloudx/client/command_helper.go
+++ b/cmd/cloudx/client/command_helper.go
@@ -8,16 +8,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/pkg/browser"
 	"io"
 	"net/http"
 	"os"
 	"os/user"
 	"strings"
 
-	"github.com/ory/x/pointerx"
-
 	"github.com/gofrs/uuid"
+	"github.com/pkg/browser"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/tidwall/gjson"
@@ -26,6 +24,7 @@ import (
 	"github.com/ory/x/cmdx"
 	"github.com/ory/x/flagx"
 	"github.com/ory/x/jsonx"
+	"github.com/ory/x/pointerx"
 )
 
 const (

--- a/cmd/cloudx/client/command_helper.go
+++ b/cmd/cloudx/client/command_helper.go
@@ -8,14 +8,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/pkg/browser"
 	"io"
 	"net/http"
 	"os"
 	"os/user"
 	"strings"
-	"testing"
-
-	"github.com/pkg/browser"
 
 	"github.com/ory/x/pointerx"
 
@@ -53,7 +51,6 @@ type (
 		openBrowserHook   func(string) error
 		projectAPIKey     *string
 		workspaceAPIKey   *string
-		sessionToken      *string
 	}
 	helperOptionsContextKey struct{}
 	CommandHelperOption     func(*CommandHelper)
@@ -118,12 +115,6 @@ func WithProjectAPIKey(apiKey string) CommandHelperOption {
 func WithWorkspaceAPIKey(apiKey string) CommandHelperOption {
 	return func(h *CommandHelper) {
 		h.workspaceAPIKey = &apiKey
-	}
-}
-
-func WithSessionToken(_ testing.TB, sessionToken string) CommandHelperOption {
-	return func(h *CommandHelper) {
-		h.sessionToken = &sessionToken
 	}
 }
 

--- a/cmd/cloudx/client/sdks.go
+++ b/cmd/cloudx/client/sdks.go
@@ -68,12 +68,6 @@ func NewPublicOryProjectClient() *cloud.APIClient {
 	return cloud.NewAPIClient(conf)
 }
 
-func NewConsoleAPIClient(sessionToken string) *cloud.APIClient {
-	conf := newSDKConfiguration(CloudConsoleURL("api").String())
-	conf.HTTPClient = newOAuth2TokenClient(oauth2.StaticTokenSource(&oauth2.Token{AccessToken: sessionToken}))
-	return cloud.NewAPIClient(conf)
-}
-
 func (h *CommandHelper) newConsoleAPIClient(ctx context.Context) (_ *cloud.APIClient, err error) {
 	conf := newSDKConfiguration(CloudConsoleURL("api").String())
 	conf.HTTPClient, err = h.newConsoleHTTPClient(ctx)
@@ -87,8 +81,6 @@ func (h *CommandHelper) newConsoleHTTPClient(ctx context.Context) (*http.Client,
 	// use the workspace API key if set
 	if h.workspaceAPIKey != nil {
 		return newOAuth2TokenClient(oauth2.StaticTokenSource(&oauth2.Token{AccessToken: *h.workspaceAPIKey})), nil
-	} else if h.sessionToken != nil {
-		return newOAuth2TokenClient(oauth2.StaticTokenSource(&oauth2.Token{AccessToken: *h.sessionToken})), nil
 	}
 
 	// fall back to interactive OAuth2 flow
@@ -103,8 +95,6 @@ func (h *CommandHelper) newConsoleHTTPClient(ctx context.Context) (*http.Client,
 func (h *CommandHelper) ProjectAuthToken(ctx context.Context) (oauth2.TokenSource, func(string) *url.URL, error) {
 	if h.projectAPIKey != nil {
 		return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: *h.projectAPIKey}), CloudAPIsURL, nil
-	} else if h.sessionToken != nil {
-		return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: *h.sessionToken}), CloudConsoleURL, nil
 	}
 
 	config, err := h.GetAuthenticatedConfig(ctx)

--- a/cmd/cloudx/identity/main_test.go
+++ b/cmd/cloudx/identity/main_test.go
@@ -20,6 +20,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	ctx, _, _, defaultProject, defaultCmd = testhelpers.CreateDefaultAssets()
+	ctx, _, _, defaultProject, defaultCmd = testhelpers.CreateDefaultAssetsBrowser()
 	m.Run()
 }

--- a/cmd/cloudx/oauth2/client_test.go
+++ b/cmd/cloudx/oauth2/client_test.go
@@ -27,7 +27,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	ctx, _, _, defaultProject, defaultCmd = testhelpers.CreateDefaultAssets()
+	ctx, _, _, defaultProject, defaultCmd = testhelpers.CreateDefaultAssetsBrowser()
 	m.Run()
 }
 

--- a/cmd/cloudx/organizations/organizations_test.go
+++ b/cmd/cloudx/organizations/organizations_test.go
@@ -23,7 +23,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	_, _, _, defaultProject, defaultCmd = testhelpers.CreateDefaultAssets()
+	_, _, _, defaultProject, defaultCmd = testhelpers.CreateDefaultAssetsBrowser()
 	m.Run()
 }
 

--- a/cmd/cloudx/project/list_test.go
+++ b/cmd/cloudx/project/list_test.go
@@ -22,10 +22,21 @@ func TestListProject(t *testing.T) {
 	t.Parallel()
 
 	// this test needs a separate account to properly list projects
-	_, _, _, sessionToken := testhelpers.RegisterAccount(context.Background(), t)
 	ctx := client.ContextWithOptions(ctx,
-		client.WithSessionToken(t, sessionToken),
 		client.WithConfigLocation(testhelpers.NewConfigFile(t)))
+
+	email, password, _, _ := testhelpers.RegisterAccount(context.Background(), t)
+	_, page, cleanup := testhelpers.SetupPlaywright(t)
+	t.Cleanup(cleanup)
+	h, err := client.NewCommandHelper(
+		ctx,
+		client.WithQuiet(false),
+		client.WithOpenBrowserHook(testhelpers.PlaywrightAcceptConsentBrowserHook(t, page, email, password)),
+	)
+	require.NoError(t, err)
+	require.NoError(t, h.Authenticate(ctx))
+	cleanup()
+
 	cmd := testhelpers.Cmd(ctx)
 
 	projects := make([]*cloud.Project, 3)

--- a/cmd/cloudx/project/main_test.go
+++ b/cmd/cloudx/project/main_test.go
@@ -21,6 +21,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	ctx, defaultConfig, extraProject, defaultProject, defaultCmd = testhelpers.CreateDefaultAssets()
+	ctx, defaultConfig, extraProject, defaultProject, defaultCmd = testhelpers.CreateDefaultAssetsBrowser()
 	m.Run()
 }

--- a/cmd/cloudx/project/patch_test.go
+++ b/cmd/cloudx/project/patch_test.go
@@ -21,54 +21,54 @@ func TestPatchProject(t *testing.T) {
 		{
 			name: "is able to replace a key",
 			doPatch: func(t *testing.T, exec execFunc) {
-				stdout, _, err := exec(nil, "patch", "project", "--format", "json", "--replace", `/services/identity/config/selfservice/methods/password/enabled=false`)
-				require.NoError(t, err)
+				stdout, stderr, err := exec(nil, "patch", "project", "--format", "json", "--replace", `/services/identity/config/selfservice/methods/password/enabled=false`)
+				require.NoError(t, err, "stdout: %s\nstderr: %s", stdout, stderr)
 				assert.False(t, gjson.Get(stdout, "services.identity.config.selfservice.methods.password.enabled").Bool())
 			},
 		},
 		{
 			name: "is able to add a key",
 			doPatch: func(t *testing.T, exec execFunc) {
-				stdout, _, err := exec(nil, "patch", "project", "--format", "json", "--add", `/services/identity/config/selfservice/methods/password/enabled=false`)
-				require.NoError(t, err)
+				stdout, stderr, err := exec(nil, "patch", "project", "--format", "json", "--add", `/services/identity/config/selfservice/methods/password/enabled=false`)
+				require.NoError(t, err, "stdout: %s\nstderr: %s", stdout, stderr)
 				assert.False(t, gjson.Get(stdout, "services.identity.config.selfservice.methods.password.enabled").Bool())
 			},
 		},
 		{
 			name: "is able to add a key with string",
 			doPatch: func(t *testing.T, exec execFunc) {
-				stdout, _, err := exec(nil, "patch", "project", "--format", "json", "--replace", "/services/identity/config/selfservice/flows/error/ui_url=\"https://example.com/error-ui\"")
-				require.NoError(t, err)
+				stdout, stderr, err := exec(nil, "patch", "project", "--format", "json", "--replace", "/services/identity/config/selfservice/flows/error/ui_url=\"https://example.com/error-ui\"")
+				require.NoError(t, err, "stdout: %s\nstderr: %s", stdout, stderr)
 				assert.Equal(t, "https://example.com/error-ui", gjson.Get(stdout, "services.identity.config.selfservice.flows.error.ui_url").String())
 			},
 		},
 		{
 			name: "is able to add a key with raw json",
 			doPatch: func(t *testing.T, exec execFunc) {
-				stdout, _, err := exec(nil, "patch", "project", "--format", "json", "--replace", `/services/identity/config/selfservice/flows/error={"ui_url":"https://example.org/error-ui"}`)
-				require.NoError(t, err)
+				stdout, stderr, err := exec(nil, "patch", "project", "--format", "json", "--replace", `/services/identity/config/selfservice/flows/error={"ui_url":"https://example.org/error-ui"}`)
+				require.NoErrorf(t, err, "stdout: %s\nstderr: %s", stdout, stderr)
 				assert.Equal(t, "https://example.org/error-ui", gjson.Get(stdout, "services.identity.config.selfservice.flows.error.ui_url").String())
 			},
 		},
 		{
 			name: "is able to remove a key",
 			doPatch: func(t *testing.T, exec execFunc) {
-				stdout, _, err := exec(nil, "patch", "project", "--format", "json", "--remove", `/services/identity/config/selfservice/methods/password/enabled`)
-				require.NoError(t, err)
+				stdout, stderr, err := exec(nil, "patch", "project", "--format", "json", "--remove", `/services/identity/config/selfservice/methods/password/enabled`)
+				require.NoErrorf(t, err, "stdout: %s\nstderr: %s", stdout, stderr)
 				assert.True(t, gjson.Get(stdout, "services.identity.config.selfservice.methods.password.enabled").Bool())
 			},
 		},
 		{
 			name: "fails if no opts are given",
 			doPatch: func(t *testing.T, exec execFunc) {
-				stdout, _, err := exec(nil, "patch", "project", "--format", "json")
-				require.Error(t, err, stdout)
+				stdout, stderr, err := exec(nil, "patch", "project", "--format", "json")
+				require.Errorf(t, err, "stdout: %s\nstderr: %s", stdout, stderr)
 			},
 		},
 		{
 			name: "is able to update several keys",
 			doPatch: func(t *testing.T, exec execFunc) {
-				stdout, _, err := exec(nil, "patch", "project", "--format", "json",
+				stdout, stderr, err := exec(nil, "patch", "project", "--format", "json",
 					"--replace", `/services/identity/config/selfservice/methods/link/enabled=true`,
 					"--replace", `/services/identity/config/selfservice/methods/oidc/enabled=true`,
 					"--remove", `/services/identity/config/selfservice/methods/profile/enabled`,
@@ -78,7 +78,7 @@ func TestPatchProject(t *testing.T) {
 					"-f", "fixtures/patch/1.json",
 					"-f", "fixtures/patch/2.json",
 				)
-				require.NoError(t, err)
+				require.NoErrorf(t, err, "stdout: %s\nstderr: %s", stdout, stderr)
 				assert.True(t, gjson.Get(stdout, "services.identity.config.selfservice.methods.password.enabled").Bool())
 				assert.True(t, gjson.Get(stdout, "services.identity.config.selfservice.methods.profile.enabled").Bool())
 				assert.True(t, gjson.Get(stdout, "services.identity.config.selfservice.methods.link.enabled").Bool())
@@ -92,8 +92,6 @@ func TestPatchProject(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
 			runWithProjectAsDefault(ctx, t, defaultProject.Id, tc.doPatch)
 			runWithProjectAsArgument(ctx, t, extraProject.Id, tc.doPatch)
 		})


### PR DESCRIPTION
Since we added OAuth2 login, we still used session tokens for some tests. This now eliminates that usage, ensuring that all endpoints work with OAuth2 access tokens (still found one during this PR).