### PR TITLE
fix: redirect user before finalizing OAuth2 login

### DIFF
--- a/cmd/cloudx/client/auth.go
+++ b/cmd/cloudx/client/auth.go
@@ -225,8 +225,8 @@ func (h *CommandHelper) oAuth2DanceWithServer(ctx context.Context, client *oauth
 				serverErr <- fmt.Errorf("failed OAuth2 token exchange: %w", err)
 				return
 			}
-			serverToken <- t
 			redirectOK(w, r)
+			serverToken <- t
 		}),
 	}
 	go func() { _ = srv.Serve(l) }()


### PR DESCRIPTION
This fixes a timing issue where the CLI can finish the login and closes the callback server before the browser has been redirected and the user sees this instead of being sent to the console with the success message
<img width="637" alt="image" src="https://github.com/user-attachments/assets/ca12827d-d412-4e9d-b16d-b55caec862be">
