### PR TITLE
fix: run goreleaser check as soft

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,7 @@ includes:
 variables:
   brew_name: cli
 
-  brew_description: "Use Ory from the your terminal!"
+  brew_description: "Use Ory from your terminal!"
 
   buildinfo_hash: "github.com/ory/cli/buildinfo.GitHash"
   buildinfo_tag: "github.com/ory/cli/buildinfo.Version"

--- a/cmd/dev/release/publish.go
+++ b/cmd/dev/release/publish.go
@@ -127,7 +127,7 @@ Are you sure you want to proceed without creating a pre version first?`, current
 			pkg.Confirm("You are about to release a non-test release v%s but did not include the --include-changelog-since flag. Are you sure you want to continue?", nextVersion)
 		}
 
-		pkg.Check(pkg.NewCommand("goreleaser", "check").Run())
+		pkg.Check(pkg.NewCommand("goreleaser", "check", "--soft").Run())
 
 		if dry {
 			fmt.Println("Don't worry, this is a dry run!")


### PR DESCRIPTION
This prevents deprecation notices from failing the pipeline. The main problem is that `dockers` is considered deprecated, while `dockers_v2` is in alpha. Soft only fails on syntax errors.