### PR TITLE
fix: broken stdin during `ory dev release publish`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,11 @@ licenses: .bin/licenses node_modules  # checks open-source licenses
 docker:
 	docker build -f .docker/Dockerfile-build -t oryd/ory:latest-sqlite .
 
+# Dummy target for ory/ci pipeline to run after a release has been made. Needs to exist or release pipeline fails.
+.PHONY: post-release
+post-release:
+	echo "nothing to do"
+
 node_modules: package-lock.json
 	npm ci
 	touch node_modules

--- a/cmd/cloudx/testhelpers/testhelpers.go
+++ b/cmd/cloudx/testhelpers/testhelpers.go
@@ -286,7 +286,10 @@ func NewPage(t testing.TB, browser playwright.Browser) playwright.Page {
 		require.NoError(t, page.Context().Route(func(actual string) bool {
 			return strings.Contains(actual, route)
 		}, func(r playwright.Route) {
-			require.NoError(t, r.Abort())
+			// Best-effort: the page may already be closed during teardown, in
+			// which case Abort returns "target closed" for a request we no
+			// longer care about. Failing the test here races test completion.
+			_ = r.Abort()
 		}))
 	}
 	return page

--- a/cmd/pkg/git.go
+++ b/cmd/pkg/git.go
@@ -16,6 +16,10 @@ import (
 
 const GitCommitMessagePreviousVersion = "Bumps from"
 
+// stdin is shared across all prompts. Creating a fresh bufio.Reader per prompt
+// discards read-ahead input, which breaks piped stdin and typed-ahead answers.
+var stdin = bufio.NewReader(os.Stdin)
+
 func NewCommand(name string, args ...string) *exec.Cmd {
 	_, _ = fmt.Fprintf(os.Stderr, "$ %s %s\n", name, strings.Join(args, " "))
 	ec := exec.Command(name, args...)
@@ -43,9 +47,8 @@ func GitTagRelease(dir string, annotate, dry bool, nextVersion semver.Version, p
 	Check(NewCommandIn(dir, "git", gitArgs...).Run())
 
 	if annotate {
-		tag := NewCommandIn(dir, "git", "tag", fmt.Sprintf("v%s", nextVersion.String()), "-a")
-		tag.Stdin = os.Stdin
-		Check(tag.Run())
+		message := promptTagMessage(nextVersion)
+		Check(NewCommandIn(dir, "git", "tag", fmt.Sprintf("v%s", nextVersion.String()), "-a", "-m", message).Run())
 	} else {
 		Check(NewCommandIn(dir, "git", "tag", fmt.Sprintf("v%s", nextVersion.String())).Run())
 	}
@@ -64,11 +67,34 @@ func GitClone(repo string) string {
 	return dest
 }
 
+// promptTagMessage reads the annotated tag message from stdin. Opening
+// $EDITOR instead is not safe here: handing the inherited terminal to vim
+// mid-run can leave the terminal in a broken state and subsequent stdin
+// reads fail with EOF.
+func promptTagMessage(version semver.Version) string {
+	fmt.Printf("Enter the tag message for v%s. Finish with an empty line:\n> ", version.String())
+	var lines []string
+	for {
+		line, err := stdin.ReadString('\n')
+		Check(err)
+
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			if len(lines) > 0 {
+				return strings.Join(lines, "\n")
+			}
+			fmt.Print("The tag message must not be empty.\n> ")
+			continue
+		}
+		lines = append(lines, line)
+		fmt.Print("> ")
+	}
+}
+
 func Confirm(message string, args ...interface{}) {
 	for {
-		reader := bufio.NewReader(os.Stdin)
 		fmt.Printf("%s [y/n] ", fmt.Sprintf(message, args...))
-		answer, err := reader.ReadString('\n')
+		answer, err := stdin.ReadString('\n')
 		Check(err)
 
 		answer = strings.TrimSpace(answer)


### PR DESCRIPTION
### What was happening

For a non-pre release, pkg.GitTagRelease ran git tag vX.Y.Z -a and handed the process's stdin to git, which spawned vim (cmd/pkg/git.go:46-48). Handing the inherited terminal to a full-screen editor mid-run is fragile: when vim exits, it restores the termios state it saw at startup, and if anything in the session had left the terminal non-canonical, every later stdin read returns EOF. The next thing ory does after the tag is Confirm("Pressing [y] will push…"), whose ReadString got that EOF → pkg.Check printed "An unexpected error occurred: EOF" and exited, leaving the terminal in the raw state (that's the "buggered terminal"; reset or stty sane recovers it). I reproduced the full flow — including your tag.gpgsign=true SSH signing — under a pseudo-terminal where it happens to work, so the corruption is triggered by something specific to your live terminal session, but the editor handoff is the fragile link either way.

### The fix (in cmd/pkg/git.go)
- The annotated-tag path now prompts Enter the tag message for vX.Y.Z. Finish with an empty line: and passes the (possibly multi-line) message via git tag -a -m …. No editor, no terminal handoff.
- Confirm had a second real bug: it created a fresh bufio.Reader(os.Stdin) per prompt, so any read-ahead input was silently discarded (with piped stdin the first prompt slurps all the answers and the next one hangs forever — I hit this while reproducing). All prompts now share one package-level reader.