### PR TITLE
fix: raise the proxy and tunnel read and write timeouts to 120s

### DIFF
--- a/cmd/cloudx/proxy/helpers.go
+++ b/cmd/cloudx/proxy/helpers.go
@@ -239,6 +239,12 @@ func runReverseProxy(ctx context.Context, h *client.CommandHelper, stdErr io.Wri
 	server := graceful.WithDefaults(&http.Server{
 		Addr:    addr,
 		Handler: ch.Handler(mw),
+		// graceful.WithDefaults would otherwise apply a 5s read and 10s write
+		// timeout, which cut slower exchanges off mid-flight and leave the client
+		// with an empty reply. The upstream here is the developer's own
+		// application and may legitimately take longer than that.
+		ReadTimeout:  120 * time.Second,
+		WriteTimeout: 120 * time.Second,
 	})
 
 	if conf.isTunnel {


### PR DESCRIPTION
Closes #302

`graceful.WithDefaults` applies a 5s read and 10s write timeout to the proxy and tunnel server. Any exchange slower than that was cut off mid-flight, so the client got an empty reply with no status and no error:

```
$ curl localhost:4000/long -v
* Empty reply from server
curl: (52) Empty reply from server
```

The reporter's observed 9.5s-works / 10.5s-fails boundary matches the 10s write deadline exactly. The read timeout caused the same silent truncation for slow or large request bodies. The upstream here is the developer's own application and may legitimately take longer than either.

Raises both to 120s. `graceful.WithDefaults` only fills in zero values, so non-zero values set on the server pass through untouched.

Note that `ReadHeaderTimeout` stays at graceful's 5s, since `net/http` prefers it over `ReadTimeout` for the header phase — request headers still have to arrive promptly, while the body now gets the full 120s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYzGVwAKQ4ormxRHZg1eDu