### PR TITLE
feat: add `ory use workspace`

### DIFF
--- a/cmd/cloudx/client/command_helper.go
+++ b/cmd/cloudx/client/command_helper.go
@@ -34,7 +34,10 @@ const (
 	ProjectAPIKey   = "ORY_PROJECT_API_KEY"
 )
 
-var ErrProjectNotSet = fmt.Errorf("no project was specified")
+var (
+	ErrProjectNotSet   = fmt.Errorf("no project was specified")
+	ErrWorkspaceNotSet = fmt.Errorf("no workspace was specified")
+)
 
 type (
 	CommandHelper struct {

--- a/cmd/cloudx/use.go
+++ b/cmd/cloudx/use.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ory/cli/cmd/cloudx/client"
 	"github.com/ory/cli/cmd/cloudx/project"
+	"github.com/ory/cli/cmd/cloudx/workspace"
 	"github.com/ory/x/cmdx"
 )
 
@@ -19,6 +20,7 @@ func NewUseCmd() *cobra.Command {
 
 	cmd.AddCommand(
 		project.NewUseProjectCmd(),
+		workspace.NewUseWorkspaceCmd(),
 	)
 
 	client.RegisterConfigFlag(cmd.PersistentFlags())

--- a/cmd/cloudx/workspace/output.go
+++ b/cmd/cloudx/workspace/output.go
@@ -63,10 +63,6 @@ type selectedWorkspace struct {
 
 var _ cmdx.TableRow = (*selectedWorkspace)(nil)
 
-func (i selectedWorkspace) String() string {
-	return i.ID
-}
-
 func (*selectedWorkspace) Header() []string {
 	return []string{"ID"}
 }

--- a/cmd/cloudx/workspace/output.go
+++ b/cmd/cloudx/workspace/output.go
@@ -54,3 +54,27 @@ func (o outputWorkspaces) Interface() interface{} {
 func (o outputWorkspaces) Len() int {
 	return len(o)
 }
+
+// selectedWorkspace is the output of `ory use workspace`, mirroring the shape
+// `ory use project` prints.
+type selectedWorkspace struct {
+	ID string `json:"id"`
+}
+
+var _ cmdx.TableRow = (*selectedWorkspace)(nil)
+
+func (i selectedWorkspace) String() string {
+	return i.ID
+}
+
+func (*selectedWorkspace) Header() []string {
+	return []string{"ID"}
+}
+
+func (i *selectedWorkspace) Columns() []string {
+	return []string{i.ID}
+}
+
+func (i *selectedWorkspace) Interface() interface{} {
+	return i
+}

--- a/cmd/cloudx/workspace/use.go
+++ b/cmd/cloudx/workspace/use.go
@@ -1,0 +1,57 @@
+// Copyright © 2026 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package workspace
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/ory/cli/cmd/cloudx/client"
+	"github.com/ory/x/cmdx"
+)
+
+func NewUseWorkspaceCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "workspace [id]",
+		Aliases: []string{"ws"},
+		Args:    cobra.MaximumNArgs(1),
+		Short:   "Set the workspace as the default. When no id is provided, prints the currently used default workspace.",
+		Example: `$ ory use workspace ecaaa3cb-0730-4ee8-a6df-9553cdfeef89
+
+ID		ecaaa3cb-0730-4ee8-a6df-9553cdfeef89
+
+$ ory use workspace ecaaa3cb-0730-4ee8-a6df-9553cdfeef89 --format json
+
+{
+  "id": "ecaaa3cb-0730-4ee8-a6df-9553cdfeef89"
+}`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts := make([]client.CommandHelperOption, 0, 1)
+			if len(args) == 1 {
+				opts = append(opts, client.WithWorkspaceOverride(args[0]))
+			}
+			h, err := client.NewCobraCommandHelper(cmd, opts...)
+			if err != nil {
+				return err
+			}
+
+			// The helper resolves a (partial) name or ID to the workspace ID,
+			// and falls back to the one already stored in the config when no
+			// argument is given.
+			id := h.WorkspaceID()
+			if id == nil {
+				return client.ErrWorkspaceNotSet
+			}
+
+			if err := h.SelectWorkspace(*id); err != nil {
+				return cmdx.PrintOpenAPIError(cmd, err)
+			}
+
+			cmdx.PrintRow(cmd, &selectedWorkspace{ID: *id})
+			return nil
+		},
+	}
+
+	cmdx.RegisterFormatFlags(cmd.Flags())
+	return cmd
+}

--- a/cmd/cloudx/workspace/use.go
+++ b/cmd/cloudx/workspace/use.go
@@ -13,7 +13,7 @@ import (
 func NewUseWorkspaceCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "workspace [id]",
-		Aliases: []string{"ws"},
+		Aliases: []string{"workspaces", "ws"},
 		Args:    cobra.MaximumNArgs(1),
 		Short:   "Set the workspace as the default. When no id is provided, prints the currently used default workspace.",
 		Example: `$ ory use workspace ecaaa3cb-0730-4ee8-a6df-9553cdfeef89
@@ -36,15 +36,20 @@ $ ory use workspace ecaaa3cb-0730-4ee8-a6df-9553cdfeef89 --format json
 			}
 
 			// The helper resolves a (partial) name or ID to the workspace ID,
-			// and falls back to the one already stored in the config when no
-			// argument is given.
+			// and falls back to the environment or the one already stored in
+			// the config when no argument is given.
 			id := h.WorkspaceID()
 			if id == nil {
 				return client.ErrWorkspaceNotSet
 			}
 
-			if err := h.SelectWorkspace(*id); err != nil {
-				return cmdx.PrintOpenAPIError(cmd, err)
+			// Only persist when the user asked to change the default. Without
+			// an argument this command just reports the current one, which must
+			// not overwrite the stored default with e.g. an ORY_WORKSPACE value.
+			if len(args) == 1 {
+				if err := h.SelectWorkspace(*id); err != nil {
+					return cmdx.PrintOpenAPIError(cmd, err)
+				}
 			}
 
 			cmdx.PrintRow(cmd, &selectedWorkspace{ID: *id})

--- a/cmd/cloudx/workspace/use_test.go
+++ b/cmd/cloudx/workspace/use_test.go
@@ -24,9 +24,10 @@ func TestUseWorkspace(t *testing.T) {
 	t.Parallel()
 
 	const (
-		initial = "11111111-1111-1111-1111-111111111111"
-		other   = "33333333-3333-3333-3333-333333333333"
-		project = "22222222-2222-2222-2222-222222222222"
+		initial     = "11111111-1111-1111-1111-111111111111"
+		other       = "33333333-3333-3333-3333-333333333333"
+		project     = "22222222-2222-2222-2222-222222222222"
+		accessToken = "the-access-token"
 	)
 
 	newContext := func(t *testing.T, workspace string) (context.Context, string) {
@@ -35,6 +36,7 @@ func TestUseWorkspace(t *testing.T) {
 		conf := map[string]any{
 			"version":          client.ConfigVersion,
 			"selected_project": project,
+			"access_token":     map[string]any{"access_token": accessToken, "token_type": "bearer"},
 		}
 		if workspace != "" {
 			conf["selected_workspace"] = workspace
@@ -58,6 +60,32 @@ func TestUseWorkspace(t *testing.T) {
 		assert.Equal(t, initial, strings.TrimSpace(stdout))
 	})
 
+	t.Run("case=prints the default workspace as JSON", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, _ := newContext(t, initial)
+
+		stdout, _, err := testhelpers.Cmd(ctx).Exec(nil, "use", "workspace", "--format", "json")
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"id":"`+initial+`"}`, stdout)
+	})
+
+	t.Run("case=does not persist an overridden workspace when no id is given", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, location := newContext(t, initial)
+		// Simulates ORY_WORKSPACE (or a workspace API key) pointing somewhere
+		// else: printing the default must not rewrite it.
+		ctx = client.ContextWithOptions(ctx, client.WithWorkspaceOverride(other))
+
+		stdout, _, err := testhelpers.Cmd(ctx).Exec(nil, "use", "workspace", "--quiet")
+		require.NoError(t, err)
+		assert.Equal(t, other, strings.TrimSpace(stdout))
+
+		conf := testhelpers.ReadConfig(t, location)
+		assert.Equal(t, initial, conf.SelectedWorkspace.String())
+	})
+
 	t.Run("case=sets the default workspace and persists it", func(t *testing.T) {
 		t.Parallel()
 
@@ -70,6 +98,8 @@ func TestUseWorkspace(t *testing.T) {
 		conf := testhelpers.ReadConfig(t, location)
 		assert.Equal(t, other, conf.SelectedWorkspace.String())
 		assert.Equal(t, project, conf.SelectedProject.String(), "selecting a workspace must not clear the project")
+		require.NotNil(t, conf.AccessToken, "selecting a workspace must not log the user out")
+		assert.Equal(t, accessToken, conf.AccessToken.AccessToken)
 	})
 
 	t.Run("case=errors when no workspace is set", func(t *testing.T) {

--- a/cmd/cloudx/workspace/use_test.go
+++ b/cmd/cloudx/workspace/use_test.go
@@ -1,0 +1,83 @@
+// Copyright © 2026 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package workspace_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ory/cli/cmd/cloudx/client"
+	"github.com/ory/cli/cmd/cloudx/testhelpers"
+)
+
+// TestUseWorkspace covers https://github.com/ory/cli/issues/406. The command is
+// exercised against a config file only, so it needs no Ory Network access:
+// selecting an already-known workspace ID never hits the API.
+func TestUseWorkspace(t *testing.T) {
+	t.Parallel()
+
+	const (
+		initial = "11111111-1111-1111-1111-111111111111"
+		other   = "33333333-3333-3333-3333-333333333333"
+		project = "22222222-2222-2222-2222-222222222222"
+	)
+
+	newContext := func(t *testing.T, workspace string) (context.Context, string) {
+		t.Helper()
+
+		conf := map[string]any{
+			"version":          client.ConfigVersion,
+			"selected_project": project,
+		}
+		if workspace != "" {
+			conf["selected_workspace"] = workspace
+		}
+		raw, err := json.Marshal(conf)
+		require.NoError(t, err)
+
+		location := testhelpers.NewConfigFile(t)
+		require.NoError(t, os.WriteFile(location, raw, 0600))
+
+		return client.ContextWithOptions(context.Background(), client.WithConfigLocation(location)), location
+	}
+
+	t.Run("case=prints the default workspace when no id is given", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, _ := newContext(t, initial)
+
+		stdout, _, err := testhelpers.Cmd(ctx).Exec(nil, "use", "workspace", "--quiet")
+		require.NoError(t, err)
+		assert.Equal(t, initial, strings.TrimSpace(stdout))
+	})
+
+	t.Run("case=sets the default workspace and persists it", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, location := newContext(t, initial)
+
+		stdout, _, err := testhelpers.Cmd(ctx).Exec(nil, "use", "workspace", other, "--quiet")
+		require.NoError(t, err)
+		assert.Equal(t, other, strings.TrimSpace(stdout))
+
+		conf := testhelpers.ReadConfig(t, location)
+		assert.Equal(t, other, conf.SelectedWorkspace.String())
+		assert.Equal(t, project, conf.SelectedProject.String(), "selecting a workspace must not clear the project")
+	})
+
+	t.Run("case=errors when no workspace is set", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, _ := newContext(t, "")
+
+		_, _, err := testhelpers.Cmd(ctx).Exec(nil, "use", "workspace", "--quiet")
+		assert.ErrorIs(t, err, client.ErrWorkspaceNotSet)
+	})
+}


### PR DESCRIPTION
Closes #406

## Problem

The [documentation](https://www.ory.sh/docs/guides/cli/cli-basics#set-the-working-context) advertises `ory use workspace <id>` for setting the default workspace, and `ory auth` prints a `SELECTED WORKSPACE` field — but the subcommand was never registered. `ory use` offered only `project`, so the workspace had to be passed via `--workspace` on every single invocation.

## Fix

The config already carried a `selected_workspace` field and `CommandHelper.SelectWorkspace` already persisted it, so this is mostly wiring. The new subcommand mirrors `ory use project`: with an argument it resolves the given ID or (partial) name and stores it; without one it reports the current default.

One bug found in review and fixed: the no-argument form was calling `SelectWorkspace` too, so merely *reading* the current default could silently rewrite it. With `ORY_WORKSPACE=B ory use workspace`, `determineWorkspaceID` prefers the env var over the config, so the "read-only" form would persist `B` over the stored value. It now only writes when an argument was actually given.

Also adds the `workspaces` alias, which every other workspace subcommand accepts — without it `ory use workspaces` matched no subcommand, printed the `use` help and **exited 0**, so a script relying on the exit code would carry on as if the workspace had been set.

## Tests

`TestUseWorkspace` runs entirely against a config file, so unlike its `cmd/cloudx` neighbours it needs no Ory Network access — selecting a known workspace ID never hits the API. It covers printing the default, the `--format json` shape the command's own example advertises, persisting a new default, the not-set error, and the read-only regression above (verified to fail against the pre-fix code).

The persist test also asserts the access token survives the config rewrite: `SelectWorkspace` re-encodes the whole config with `O_TRUNC`, so a partially populated struct would silently log the user out.

## Known limitations, deliberately not addressed here

These all apply equally to the existing `ory use project` and live in unchanged shared code, so they belong in a separate change rather than being special-cased for workspaces:

- A well-formed but wrong UUID is persisted without validation and reports success, because `determineWorkspaceID` takes the `uuid.FromString` fast path and never contacts the API. Later workspace-scoped commands then fail with an opaque 403/404.
- With `ORY_PROJECT_API_KEY` exported, `ory use workspace <id>` fails with "project API key is set but workspace is also set" — the user has to unset an unrelated env var.
- A set-but-empty `ORY_WORKSPACE` suppresses the config fallback, so the command reports "no workspace was specified" even with a default stored.
- Switching workspaces leaves `selected_project` pointing at a project in the old workspace. The test asserts the project is *not* cleared, so this is a conscious choice — flagged in case you would rather it were.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYzGVwAKQ4ormxRHZg1eDu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `cloudx use workspace [id]` to select and display the active workspace.
  * Supports quiet and JSON output formats.
  * Preserves existing project and authentication settings when changing workspaces.
  * Reports a clear error when no workspace is configured.

* **Tests**
  * Added coverage for workspace selection, output formats, configuration persistence, overrides, and missing workspace settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->